### PR TITLE
Feature/#14 create auth customer

### DIFF
--- a/src/.rubocop.yml
+++ b/src/.rubocop.yml
@@ -70,3 +70,9 @@ Metrics/MethodLength:
 # テストタイプの推論を無効にする
 RSpecRails/InferredSpecType:
   Enabled: false
+
+# 未定義メソッドの警告を無効
+Rails/LexicallyScopedActionFilter:
+  Exclude:
+    - "app/controllers/admin_accounts/registrations_controller.rb"
+    - "app/controllers/customer_accounts/registrations_controller.rb"

--- a/src/app/controllers/admin_accounts/confirmations_controller.rb
+++ b/src/app/controllers/admin_accounts/confirmations_controller.rb
@@ -20,7 +20,6 @@ class AdminAccounts::ConfirmationsController < Devise::ConfirmationsController
 
   # The path used after resending confirmation instructions.
   def after_resending_confirmation_instructions_path_for(_resource_name)
-    flash[:notice] = '確認メールを再送しました。メールを確認してください。'
     new_admin_account_confirmation_path
   end
 

--- a/src/app/controllers/admin_accounts/registrations_controller.rb
+++ b/src/app/controllers/admin_accounts/registrations_controller.rb
@@ -55,7 +55,7 @@ class AdminAccounts::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up for inactive accounts.
-  def after_inactive_sign_up_path_for(resource)
+  def after_inactive_sign_up_path_for(_resource)
     new_admin_account_registration_path
   end
 end

--- a/src/app/controllers/admin_accounts/registrations_controller.rb
+++ b/src/app/controllers/admin_accounts/registrations_controller.rb
@@ -9,9 +9,9 @@ class AdminAccounts::RegistrationsController < Devise::RegistrationsController
   # end
 
   # POST /resource
-  def create
-    super
-  end
+  # def create
+  #   super
+  # end
 
   # GET /resource/edit
   # def edit

--- a/src/app/controllers/admin_accounts/registrations_controller.rb
+++ b/src/app/controllers/admin_accounts/registrations_controller.rb
@@ -10,12 +10,7 @@ class AdminAccounts::RegistrationsController < Devise::RegistrationsController
 
   # POST /resource
   def create
-    super do |resource|
-      if resource.persisted?
-        flash[:notice] = 'あなたのメールアドレスへ確認メールを送信しました。メールを開いてリンクへアクセスしてください。'
-        redirect_to registration_path(resource_name) and return
-      end
-    end
+    super
   end
 
   # GET /resource/edit
@@ -60,7 +55,7 @@ class AdminAccounts::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_inactive_sign_up_path_for(resource)
+    new_admin_account_registration_path
+  end
 end

--- a/src/app/controllers/customer_accounts/confirmations_controller.rb
+++ b/src/app/controllers/customer_accounts/confirmations_controller.rb
@@ -16,16 +16,17 @@ class CustomerAccounts::ConfirmationsController < Devise::ConfirmationsControlle
   #   super
   # end
 
-  # protected
+  protected
 
   # The path used after resending confirmation instructions.
-  # def after_resending_confirmation_instructions_path_for(resource_name)
-  #   super(resource_name)
-  # end
+  def after_resending_confirmation_instructions_path_for(_resource_name)
+    new_customer_account_confirmation_path
+  end
 
   # The path used after confirmation.
   def after_confirmation_path_for(resource_name, resource)
-    super(resource_name, resource)
-    sample_path
+    sign_in(resource)
+    # TODO: 遷移先をTOPページに変更する
+    customer_test_path
   end
 end

--- a/src/app/controllers/customer_accounts/confirmations_controller.rb
+++ b/src/app/controllers/customer_accounts/confirmations_controller.rb
@@ -24,7 +24,7 @@ class CustomerAccounts::ConfirmationsController < Devise::ConfirmationsControlle
   end
 
   # The path used after confirmation.
-  def after_confirmation_path_for(resource_name, resource)
+  def after_confirmation_path_for(_resource_name, resource)
     sign_in(resource)
     # TODO: 遷移先をTOPページに変更する
     customer_test_path

--- a/src/app/controllers/customer_accounts/confirmations_controller.rb
+++ b/src/app/controllers/customer_accounts/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CustomerAccounts::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/src/app/controllers/customer_accounts/confirmations_controller.rb
+++ b/src/app/controllers/customer_accounts/confirmations_controller.rb
@@ -24,7 +24,8 @@ class CustomerAccounts::ConfirmationsController < Devise::ConfirmationsControlle
   # end
 
   # The path used after confirmation.
-  # def after_confirmation_path_for(resource_name, resource)
-  #   super(resource_name, resource)
-  # end
+  def after_confirmation_path_for(resource_name, resource)
+    super(resource_name, resource)
+    sample_path
+  end
 end

--- a/src/app/controllers/customer_accounts/omniauth_callbacks_controller.rb
+++ b/src/app/controllers/customer_accounts/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CustomerAccounts::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/src/app/controllers/customer_accounts/passwords_controller.rb
+++ b/src/app/controllers/customer_accounts/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class CustomerAccounts::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/src/app/controllers/customer_accounts/passwords_controller.rb
+++ b/src/app/controllers/customer_accounts/passwords_controller.rb
@@ -21,14 +21,14 @@ class CustomerAccounts::PasswordsController < Devise::PasswordsController
   #   super
   # end
 
-  # protected
+  protected
 
-  # def after_resetting_password_path_for(resource)
-  #   super(resource)
-  # end
+  def after_resetting_password_path_for(resource)
+    new_customer_account_session_path
+  end
 
   # The path used after sending reset password instructions
-  # def after_sending_reset_password_instructions_path_for(resource_name)
-  #   super(resource_name)
-  # end
+  def after_sending_reset_password_instructions_path_for(resource_name)
+    new_customer_account_password_path
+  end
 end

--- a/src/app/controllers/customer_accounts/passwords_controller.rb
+++ b/src/app/controllers/customer_accounts/passwords_controller.rb
@@ -23,12 +23,12 @@ class CustomerAccounts::PasswordsController < Devise::PasswordsController
 
   protected
 
-  def after_resetting_password_path_for(resource)
+  def after_resetting_password_path_for(_resource)
     new_customer_account_session_path
   end
 
   # The path used after sending reset password instructions
-  def after_sending_reset_password_instructions_path_for(resource_name)
+  def after_sending_reset_password_instructions_path_for(_resource_name)
     new_customer_account_password_path
   end
 end

--- a/src/app/controllers/customer_accounts/registrations_controller.rb
+++ b/src/app/controllers/customer_accounts/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CustomerAccounts::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
@@ -38,12 +38,12 @@ class CustomerAccounts::RegistrationsController < Devise::RegistrationsControlle
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:user_name])
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params
@@ -56,7 +56,7 @@ class CustomerAccounts::RegistrationsController < Devise::RegistrationsControlle
   # end
 
   # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_inactive_sign_up_path_for(resource)
+    new_customer_account_registration_path
+  end
 end

--- a/src/app/controllers/customer_accounts/registrations_controller.rb
+++ b/src/app/controllers/customer_accounts/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class CustomerAccounts::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/src/app/controllers/customer_accounts/registrations_controller.rb
+++ b/src/app/controllers/customer_accounts/registrations_controller.rb
@@ -56,7 +56,7 @@ class CustomerAccounts::RegistrationsController < Devise::RegistrationsControlle
   # end
 
   # The path used after sign up for inactive accounts.
-  def after_inactive_sign_up_path_for(resource)
+  def after_inactive_sign_up_path_for(_resource)
     new_customer_account_registration_path
   end
 end

--- a/src/app/controllers/customer_accounts/sessions_controller.rb
+++ b/src/app/controllers/customer_accounts/sessions_controller.rb
@@ -14,9 +14,22 @@ class CustomerAccounts::SessionsController < Devise::SessionsController
   # end
 
   # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
+  def destroy
+    super do
+      flash.clear
+    end
+  end
+
+  # ログイン後のリダイレクト先
+  def after_sign_in_path_for(_resource)
+    # TODO: ダッシュボード画面のパスに変更する
+    customer_test_path
+  end
+
+  # ログアウト後のリダイレクト先
+  def after_sign_out_path_for(_resource)
+    customer_account_session_path
+  end
 
   # protected
 

--- a/src/app/controllers/customer_accounts/sessions_controller.rb
+++ b/src/app/controllers/customer_accounts/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CustomerAccounts::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/src/app/controllers/customer_accounts/unlocks_controller.rb
+++ b/src/app/controllers/customer_accounts/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CustomerAccounts::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/src/app/controllers/customer_tests_controller.rb
+++ b/src/app/controllers/customer_tests_controller.rb
@@ -1,5 +1,5 @@
 class CustomerTestsController < ApplicationController
-    before_action :authenticate_customer_account!
+  before_action :authenticate_customer_account!
 
-    def index; end
+  def index; end
 end

--- a/src/app/controllers/customer_tests_controller.rb
+++ b/src/app/controllers/customer_tests_controller.rb
@@ -1,0 +1,5 @@
+class CustomerTestsController < ApplicationController
+    before_action :authenticate_customer_account!
+
+    def index; end
+end

--- a/src/app/models/admin_account.rb
+++ b/src/app/models/admin_account.rb
@@ -1,9 +1,8 @@
 class AdminAccount < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
-         :confirmable, :timeoutable
+  devise :database_authenticatable, :timeoutable,
+         :rememberable, :validatable
 
   validates :password, format: {
     with: /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i

--- a/src/app/models/customer_account.rb
+++ b/src/app/models/customer_account.rb
@@ -1,0 +1,7 @@
+class CustomerAccount < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable,
+         :confirmable, :timeoutable
+end

--- a/src/app/models/customer_account.rb
+++ b/src/app/models/customer_account.rb
@@ -4,4 +4,8 @@ class CustomerAccount < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :confirmable, :timeoutable
+
+  validates :password, format: {
+    with: /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i
+  }, on: :create
 end

--- a/src/app/views/customer_accounts/confirmations/new.html.erb
+++ b/src/app/views/customer_accounts/confirmations/new.html.erb
@@ -1,16 +1,30 @@
-<h2>Resend confirmation instructions</h2>
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>確認メール再送信</title>
+</head>
+<body class="bg-gray-100">
+  <main class="min-h-screen flex items-center justify-center">
+    <div class="w-full max-w-md p-6 bg-white shadow-md rounded-lg">
+      <h1 class="text-center text-3xl mb-6">確認メール再送信</h1>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "customer_accounts/shared/error_messages", resource: resource %>
+      <%= render "shared/flash" %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
-  </div>
-<% end %>
-
-<%= render "customer_accounts/shared/links" %>
+      <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
+        <div>
+          <%= f.label :email, "メールアドレス", class: "block font-medium text-gray-700" %>
+          <%= f.email_field :email, autofocus: true, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm", placeholder: "email@example.com" %>
+        </div>
+        <div>
+          <%= f.submit "確認メール再送信", class: "w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-sky-400 hover:bg-sky-500" %>
+        </div>
+      <% end %>
+      <div class="mt-6 text-center">
+        <%= render "admin_accounts/shared/links" %>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/src/app/views/customer_accounts/confirmations/new.html.erb
+++ b/src/app/views/customer_accounts/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "customer_accounts/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "customer_accounts/shared/links" %>

--- a/src/app/views/customer_accounts/mailer/confirmation_instructions.html.erb
+++ b/src/app/views/customer_accounts/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/src/app/views/customer_accounts/mailer/confirmation_instructions.html.erb
+++ b/src/app/views/customer_accounts/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,9 @@
-<p>Welcome <%= @email %>!</p>
+<p>こんにちは <%= @resource.email %> 様,</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p>下のリンクをクリックして、メールアドレスの確認を完了してください。</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to 'メールアドレスを確認する', confirmation_url(@resource, confirmation_token: @token) %></p>
+
+<p>このメールに心当たりがない場合は、無視してください。</p>
+
+<p>よろしくお願いします。</p>

--- a/src/app/views/customer_accounts/mailer/email_changed.html.erb
+++ b/src/app/views/customer_accounts/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/src/app/views/customer_accounts/mailer/password_change.html.erb
+++ b/src/app/views/customer_accounts/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/src/app/views/customer_accounts/mailer/reset_password_instructions.html.erb
+++ b/src/app/views/customer_accounts/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/src/app/views/customer_accounts/mailer/reset_password_instructions.html.erb
+++ b/src/app/views/customer_accounts/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>こんにちは <%= @resource.email %> 様,</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワードの変更リクエストがありました。以下のリンクから新しいパスワードを設定してください。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワードを変更する', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>このリクエストに心当たりがない場合は、このメールを無視してください。リンクをクリックして新しいパスワードを作成するまで、パスワードは変更されません。</p>
+

--- a/src/app/views/customer_accounts/mailer/unlock_instructions.html.erb
+++ b/src/app/views/customer_accounts/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/src/app/views/customer_accounts/passwords/edit.html.erb
+++ b/src/app/views/customer_accounts/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "customer_accounts/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "customer_accounts/shared/links" %>

--- a/src/app/views/customer_accounts/passwords/edit.html.erb
+++ b/src/app/views/customer_accounts/passwords/edit.html.erb
@@ -1,25 +1,38 @@
-<h2>Change your password</h2>
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>パスワード再設定</title>
+</head>
+<body class="bg-gray-100">
+  <main class="min-h-screen flex items-center justify-center">
+    <div class="w-full max-w-md p-6 bg-white shadow-md rounded-lg">
+      <h1 class="text-center text-3xl mb-6">パスワード再設定</h1>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "customer_accounts/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+      <%= render "shared/flash" %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "space-y-4" }) do |f| %>
+        <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+        <div>
+          <%= f.label :password, "新しいパスワード", class: "block font-medium text-gray-700" %>
+          <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm", placeholder: "半角英数記号8文字以上" %>
+        </div>
 
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
+        <div>
+          <%= f.label :password_confirmation, "新しいパスワード(確認用)", class: "block font-medium text-gray-700" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm", placeholder: "パスワードと同じ文字列" %>
+        </div>
 
-<%= render "customer_accounts/shared/links" %>
+        <div>
+          <%= f.submit "パスワード変更", class: "w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-sky-400 hover:bg-sky-500" %>
+        </div>
+      <% end %>
+      <div class="mt-6 text-center">
+        <%= render "admin_accounts/shared/links" %>
+      </div>
+    </div>
+  </main>
+
+

--- a/src/app/views/customer_accounts/passwords/new.html.erb
+++ b/src/app/views/customer_accounts/passwords/new.html.erb
@@ -1,16 +1,33 @@
-<h2>Forgot your password?</h2>
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>パスワード再発行</title>
+</head>
+<body class="bg-gray-100">
+  <main class="min-h-screen flex items-center justify-center">
+    <div class="w-full max-w-md p-6 bg-white shadow-md rounded-lg">
+      <h1 class="text-center text-3xl mb-6">パスワード再発行</h1>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "customer_accounts/shared/error_messages", resource: resource %>
+      <%= render "shared/flash" %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "customer_accounts/shared/links" %>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
+        <p class="text-gray-500 mb-4">
+          入力されたメールアドレスへパスワードの再設定用メールを送信します。
+        </p>
+        <div>
+          <%= f.label :email, "メールアドレス", class: "block font-medium text-gray-700" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm", placeholder: "email@example.com" %>
+        </div>
+        <div>
+          <%= f.submit "送信", class: "w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-sky-400 hover:bg-sky-500" %>
+        </div>
+      <% end %>
+      <div class="mt-6 text-center">
+        <%= render "admin_accounts/shared/links" %>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/src/app/views/customer_accounts/passwords/new.html.erb
+++ b/src/app/views/customer_accounts/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "customer_accounts/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "customer_accounts/shared/links" %>

--- a/src/app/views/customer_accounts/registrations/edit.html.erb
+++ b/src/app/views/customer_accounts/registrations/edit.html.erb
@@ -1,0 +1,43 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "customer_accounts/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+
+<%= link_to "Back", :back %>

--- a/src/app/views/customer_accounts/registrations/new.html.erb
+++ b/src/app/views/customer_accounts/registrations/new.html.erb
@@ -1,29 +1,42 @@
-<h2>Sign up</h2>
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>アカウント作成</title>
+</head>
+<body class="bg-gray-100">
+  <main class="min-h-screen flex items-center justify-center">
+    <div class="w-full max-w-md p-6 bg-white shadow-md rounded-lg">
+      <h1 class="text-center text-3xl mb-6">アカウント作成</h1>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "customer_accounts/shared/error_messages", resource: resource %>
+      <%= render "shared/flash" %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "customer_accounts/shared/links" %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
+        <div>
+          <%= f.label :user_name, "ユーザー名", class: "block font-medium text-gray-700" %>
+          <%= f.text_field :user_name, autofocus: true, autocomplete: "username", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm", placeholder: "ユーザー名" %>
+        </div>
+        <div>
+          <%= f.label :email, "メールアドレス", class: "block font-medium text-gray-700" %>
+          <%= f.email_field :email, autocomplete: "email", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm", placeholder: "email@example.com" %>
+        </div>
+        <div>
+          <%= f.label :password, "パスワード", class: "block font-medium text-gray-700" %>
+          <%= f.password_field :password, autocomplete: "new-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm", placeholder: "半角英数8文字以上" %>
+        </div>
+        <div>
+          <%= f.label :password_confirmation, "パスワード(確認用)", class: "block font-medium text-gray-700" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm", placeholder: "パスワードと同じ文字列" %>
+        </div>
+        <div>
+          <%= f.submit "アカウントを作成する", class: "w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-sky-400 hover:bg-sky-500" %>
+        </div>
+      <% end %>
+      <div class="mt-6 text-center">
+        <%= render "customer_accounts/shared/links" %>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/src/app/views/customer_accounts/registrations/new.html.erb
+++ b/src/app/views/customer_accounts/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<h2>Sign up</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= render "customer_accounts/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "customer_accounts/shared/links" %>

--- a/src/app/views/customer_accounts/sessions/new.html.erb
+++ b/src/app/views/customer_accounts/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Log in</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "current-password" %>
+  </div>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "customer_accounts/shared/links" %>

--- a/src/app/views/customer_accounts/sessions/new.html.erb
+++ b/src/app/views/customer_accounts/sessions/new.html.erb
@@ -1,26 +1,40 @@
-<h2>Log in</h2>
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ログイン</title>
+</head>
+<body class="bg-gray-100">
+  <main class="min-h-screen flex items-center justify-center">
+    <div class="w-full max-w-md p-6 bg-white shadow-md rounded-lg">
+      <h1 class="text-center text-3xl mb-6">ログイン</h1>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <%= render "shared/flash" %>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-6" }) do |f| %>
+        <%= render 'devise/shared/error_messages', resource: resource %>
+        <div>
+          <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50", placeholder: "email@example.com" %>
+        </div>
+        <div>
+          <%= f.label :password, "パスワード", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.password_field :password, autocomplete: "current-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50", placeholder: "半角英数8文字以上" %>
+        </div>
+        <div class="flex items-center">
+          <%= f.check_box :remember_me, class: "rounded" %>
+          <%= f.label :remember_me, "ログインしたままにする", class: "ml-2 block text-sm text-gray-900" %>
+        </div>
+        <div>
+          <%= f.submit "ログイン", class: "w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-sky-400 hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-500" %>
+        </div>
+      <% end %>
+      <div class="mt-6 text-center">
+        <%= render "admin_accounts/shared/links" %>
+      </div>
     </div>
-  <% end %>
+  </main>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "customer_accounts/shared/links" %>
+</body>
+</html>

--- a/src/app/views/customer_accounts/shared/_error_messages.html.erb
+++ b/src/app/views/customer_accounts/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation" data-turbo-cache="false">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/src/app/views/customer_accounts/shared/_links.html.erb
+++ b/src/app/views/customer_accounts/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+  <% end %>
+<% end %>

--- a/src/app/views/customer_accounts/shared/_links.html.erb
+++ b/src/app/views/customer_accounts/shared/_links.html.erb
@@ -1,17 +1,17 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "ログインはこちら", new_session_path(resource_name), class: "text-sky-400"  %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "アカウントを作成する", new_registration_path(resource_name), class: "text-sky-400" %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "パスワードを忘れた方", new_password_path(resource_name), class: "text-sky-400" %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "認証メールが届いていませんか？", new_confirmation_path(resource_name), class: "text-sky-400" %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>

--- a/src/app/views/customer_accounts/unlocks/new.html.erb
+++ b/src/app/views/customer_accounts/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "customer_accounts/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "customer_accounts/shared/links" %>

--- a/src/app/views/customer_tests/index.html.erb
+++ b/src/app/views/customer_tests/index.html.erb
@@ -1,0 +1,18 @@
+<header class="bg-blue-400 p-4">
+    <nav class="container mx-auto flex items-center justify-between">
+        <div class="text-4xl">Customer Test Tailwindcss</div>
+        <div class="space-x-12 font-bold">
+            <a href="" class="hover:text-green-200">ホーム</a>
+            <a href="" class="hover:text-green-200">ブログ</a>
+            <a href="" class="hover:text-green-200">お問い合わせ</a>
+            <%= link_to 'ログアウト', destroy_customer_account_session_path, data: { turbo_method: :delete }, class: 'hover:text-red-200' %>
+        </div>
+    </nav>
+</header>
+<div class="mt-60 flex w-full justify-center">
+    <button data-tooltip-target="tooltip-default" type="button" class="rounded-lg bg-blue-700 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-800 focus:outline-none focus:ring-4 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">hover me</button>
+    <div id="tooltip-default" role="tooltip" class="tooltip invisible absolute z-10 inline-block rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm transition-opacity duration-300 dark:bg-gray-700">
+        flowbite sample
+        <div class="tooltip-arrow" data-popper-arrow></div>
+    </div>
+</div>

--- a/src/config/locales/model.ja.yml
+++ b/src/config/locales/model.ja.yml
@@ -2,8 +2,14 @@ ja:
   activerecord:
     models:
       admin_account: "管理者アカウント"
+      customer_account: "顧客アカウント"
     attributes:
       admin_account:
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認）"
+        user_name: "ユーザー名"
+      customer_account:
         email: "メールアドレス"
         password: "パスワード"
         password_confirmation: "パスワード（確認）"

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  devise_for :customer_accounts
   devise_for :admin_accounts, controllers: {
     sessions: 'admin_accounts/sessions',
     registrations: 'admin_accounts/registrations',

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
 
   get 'sample', to: 'samples#index'
 
+  get 'customer-test', to: 'customer_tests#index'
+
   # Defines the root path route ("/")
   # root "posts#index"
 

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-
   # アカウント認証(カスタマー)
   devise_for :customer_accounts, controllers: {
     sessions: 'customer_accounts/sessions',

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -1,5 +1,14 @@
 Rails.application.routes.draw do
-  devise_for :customer_accounts
+
+  # アカウント認証(カスタマー)
+  devise_for :customer_accounts, controllers: {
+    sessions: 'customer_accounts/sessions',
+    registrations: 'customer_accounts/registrations',
+    confirmations: 'customer_accounts/confirmations',
+    passwords: 'customer_accounts/passwords'
+  }
+
+  # アカウント認証(管理者)
   devise_for :admin_accounts, controllers: {
     sessions: 'admin_accounts/sessions',
     registrations: 'admin_accounts/registrations',

--- a/src/db/migrate/20240512011256_devise_create_customer_accounts.rb
+++ b/src/db/migrate/20240512011256_devise_create_customer_accounts.rb
@@ -14,6 +14,10 @@ class DeviseCreateCustomerAccounts < ActiveRecord::Migration[7.1]
       ## Rememberable
       t.datetime :remember_created_at
 
+      ## 追加
+      t.string :user_name
+      t.string :status
+
       ## Trackable
       # t.integer  :sign_in_count, default: 0, null: false
       # t.datetime :current_sign_in_at
@@ -22,10 +26,10 @@ class DeviseCreateCustomerAccounts < ActiveRecord::Migration[7.1]
       # t.string   :last_sign_in_ip
 
       ## Confirmable
-      # t.string   :confirmation_token
-      # t.datetime :confirmed_at
-      # t.datetime :confirmation_sent_at
-      # t.string   :unconfirmed_email # Only if using reconfirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
@@ -38,7 +42,7 @@ class DeviseCreateCustomerAccounts < ActiveRecord::Migration[7.1]
 
     add_index :customer_accounts, :email,                unique: true
     add_index :customer_accounts, :reset_password_token, unique: true
-    # add_index :customer_accounts, :confirmation_token,   unique: true
+    add_index :customer_accounts, :confirmation_token,   unique: true
     # add_index :customer_accounts, :unlock_token,         unique: true
   end
 end

--- a/src/db/migrate/20240512011256_devise_create_customer_accounts.rb
+++ b/src/db/migrate/20240512011256_devise_create_customer_accounts.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class DeviseCreateCustomerAccounts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :customer_accounts do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :customer_accounts, :email,                unique: true
+    add_index :customer_accounts, :reset_password_token, unique: true
+    # add_index :customer_accounts, :confirmation_token,   unique: true
+    # add_index :customer_accounts, :unlock_token,         unique: true
+  end
+end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_06_102646) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_12_011256) do
   create_table "addresses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "zip_code"
     t.string "state"
@@ -37,6 +37,25 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_06_102646) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+  end
+
+  create_table "customer_accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.string "user_name"
+    t.string "status"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["confirmation_token"], name: "index_customer_accounts_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_customer_accounts_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_customer_accounts_on_reset_password_token", unique: true
   end
 
   create_table "products", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/src/db/seeds.rb
+++ b/src/db/seeds.rb
@@ -7,3 +7,15 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+require 'dotenv-rails'
+
+#### Admin Accounts ####
+admin_email = ENV['ADMIN_EMAIL']
+admin_password = ENV['ADMIN_PASSWORD']
+
+AdminAccount.find_or_create_by(email: admin_email) do |admin|
+  admin.password = admin_password
+  admin.password_confirmation = admin_password
+  admin.user_name = 'admin'
+end

--- a/src/spec/factories/customer_accounts.rb
+++ b/src/spec/factories/customer_accounts.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :customer_account do
-    
+    email { Faker::Internet.email }
+    password { 'password123' }
+    password_confirmation { 'password123' }
   end
 end

--- a/src/spec/factories/customer_accounts.rb
+++ b/src/spec/factories/customer_accounts.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :customer_account do
+    
+  end
+end

--- a/src/spec/models/admin_account_spec.rb
+++ b/src/spec/models/admin_account_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe AdminAccount, type: :model do
       end
     end
 
+    context 'when password is not alphanumeric' do
+      it 'is not valid with a password that is not a mix of letters and numbers' do
+        customer = build(:admin_account, password: 'aaaaaaaa')
+        customer.valid?
+        expect(customer.errors[:password]).to include('は不正な値です')
+      end
+    end
+
     context 'with a duplicate email' do
       before do
         create(:admin_account, email: 'admin@example.com')

--- a/src/spec/models/customer_account_spec.rb
+++ b/src/spec/models/customer_account_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CustomerAccount, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/src/spec/models/customer_account_spec.rb
+++ b/src/spec/models/customer_account_spec.rb
@@ -1,5 +1,78 @@
 require 'rails_helper'
 
 RSpec.describe CustomerAccount, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'when validating' do
+    it 'is valid with valid attributes' do
+      customer = build(:customer_account)
+      expect(customer).to be_valid
+    end
+
+    context 'when email is nil' do
+      it 'is not valid without an email' do
+        customer = build(:customer_account, email: nil)
+        expect(customer).not_to be_valid
+      end
+
+      it 'adds a correct error message for missing email' do
+        customer = build(:customer_account, email: nil)
+        customer.valid?
+        expect(customer.errors[:email]).to include('を入力してください')
+      end
+    end
+
+    context 'when password is nil' do
+      it 'is not valid without a password' do
+        customer = build(:customer_account, password: nil)
+        expect(customer).not_to be_valid
+      end
+
+      it 'adds a correct error message for missing password' do
+        customer = build(:customer_account, password: nil)
+        customer.valid?
+        expect(customer.errors[:password]).to include('を入力してください')
+      end
+    end
+
+    context 'when password is too short' do
+      it 'is not valid with a password shorter than 8 characters' do
+        customer = build(:customer_account, password: 'short')
+        customer.valid?
+        expect(customer.errors[:password]).to include('は8文字以上で入力してください')
+      end
+    end
+
+    context 'when password is too long' do
+      it 'is not valid with a password longer than 128 characters' do
+        long_password = 'a' * 129
+        customer = build(:customer_account, password: long_password)
+        customer.valid?
+        expect(customer.errors[:password]).to include('は128文字以内で入力してください')
+      end
+    end
+
+    context 'when password is not alphanumeric' do
+      it 'is not valid with a password that is not a mix of letters and numbers' do
+        customer = build(:customer_account, password: 'aaaaaaaa')
+        customer.valid?
+        expect(customer.errors[:password]).to include('は不正な値です')
+      end
+    end
+
+    context 'with a duplicate email' do
+      before do
+        create(:customer_account, email: 'customer@example.com')
+      end
+
+      it 'is not valid with a non-unique email' do
+        new_customer = build(:customer_account, email: 'customer@example.com')
+        expect(new_customer).not_to be_valid
+      end
+
+      it 'adds a correct error message for duplicate email' do
+        new_customer = build(:customer_account, email: 'customer@example.com')
+        new_customer.valid?
+        expect(new_customer.errors[:email]).to include('はすでに存在します')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 関連するIssueやプルリクエスト
#14 

## 変更の概要
基本的な実装は管理者側と同じです。
違いとしては
- 管理者側の機能はログインとremember meに絞る(現状管理者アカウントが誰でも作成できてしまうため)
- 管理者アカウントはseedで設定する
- テスト項目を追加

※管理者側の機能についてはAdminAccountモデルに設定を追記すればすぐに利用可能になるようにしてます

## なぜこの変更をするのか
- 管理者アカウントは特定の人のみアクセス許可したいため。
- 顧客が様々な追加機能にアクセスするため。

## 事前準備
管理者アカウントはseedで設定するようにしたので以下を.envファイルに追記してください。
値は変更してもらって問題ないです！
```bash
ADMIN_EMAIL=admin@example.com
ADMIN_PASSWORD=test12345
```

## やったこと
- ユーザー新規登録
- ログイン機能の実装
- ログアウト機能の実装
- アドレス確認メールの再送信
- パスワードリセット
- ログイン状態の永続化(2週間)


## どうやるのか
### 新規登録
フォームに必要事項を入力し、新規登録。</br>
<img width="513" alt="スクリーンショット 2024-05-08 22 12 35" src="https://github.com/recursion-backend-projects/E-Commerce-Webapp-with-Stripe-Sync/assets/69625901/0512c914-45ba-44ad-bf29-db0bea629a8a">

http://localhost:8025/ にアクセスしてアドレス確認メールが届いてるか確認</br>
<img width="1713" alt="スクリーンショット 2024-05-08 22 27 48" src="https://github.com/recursion-backend-projects/E-Commerce-Webapp-with-Stripe-Sync/assets/69625901/28e3aaad-bded-43f5-92a0-00734950b5cb">

確認用のリンクにアクセスして/sampleに遷移できればOK</br>
※現状は/sampleをdashboardとして実装してます。</br>

/sampleページで画面右上のログアウトボタンを押すことでログアウト可能です。</br>


### ログイン
<img width="476" alt="スクリーンショット 2024-05-08 22 19 26" src="https://github.com/recursion-backend-projects/E-Commerce-Webapp-with-Stripe-Sync/assets/69625901/2bf4665b-29a3-4ba8-ae36-5ff062bb8426">

必要事項を入力してログインボタンを押すと/sampleに遷移します。</br>
ログイン状態で認証ページにアクセスしても/sampleに戻されるようにしてます。</br>


### パスワード再発行
<img width="458" alt="スクリーンショット 2024-05-08 22 14 12" src="https://github.com/recursion-backend-projects/E-Commerce-Webapp-with-Stripe-Sync/assets/69625901/cc68b79d-b871-47cc-9862-4669e31b2756">

ログインフォーム下部の「パスワードを忘れた方」というリンクから再設定するためのメール送信フォームに遷移します</br>
ここでメールアドレスを入力し、送信すると再設定用のメールが届きます。

<img width="1234" alt="スクリーンショット 2024-05-08 22 39 30" src="https://github.com/recursion-backend-projects/E-Commerce-Webapp-with-Stripe-Sync/assets/69625901/3b7c7417-eb9f-40cb-951a-f0137df14afb">

上記の確認リンクから再設定用のリンクへ進み、パスワードの変更が可能です。


## その他変更した設定
- セッション保持時間120分
- remenber meは2週間に設定 -> remenber meを有効化した場合、2週間が経過するとセッション切れになる
- バリデーションやメールの送信完了等の通知はフラッシュメッセージで出力してます。
- フォーム下部のリンク群はdevise推奨の表示にしてます。(変更可)

## とくにレビューしてほしいところ
基本的な認証機能が正常に動作するか</br>
- ログイン・ログアウトは正常に動作するか
- 基本的なバリデーションは機能してるか
- フラッシュメッセージは問題なく表示されてるか
- 認証メール等は正常に送信されるか
- 認証周りの導線は問題ないか


## 備考

* その他に伝えたいこと