### PR TITLE
Feature/#16 save receipt

### DIFF
--- a/src/app/controllers/customer/checkouts_controller.rb
+++ b/src/app/controllers/customer/checkouts_controller.rb
@@ -17,7 +17,7 @@ class Customer::CheckoutsController < ApplicationController
                                                    allowed_countries: %w[JP]
                                                  },
                                                  # requiredにしないと、請求先は国だけ選べるという微妙な見た目になってしまう
-                                                 billing_address_collection: 'required',
+                                                 billing_address_collection: 'required'
                                                })
     redirect_to session.url, allow_other_host: true
   end

--- a/src/app/controllers/customer/checkouts_controller.rb
+++ b/src/app/controllers/customer/checkouts_controller.rb
@@ -16,7 +16,8 @@ class Customer::CheckoutsController < ApplicationController
                                                  shipping_address_collection: {
                                                    allowed_countries: %w[JP]
                                                  },
-                                                 billing_address_collection: 'required'
+                                                 # requiredにしないと、請求先は国だけ選べるという微妙な見た目になってしまう
+                                                 billing_address_collection: 'required',
                                                })
     redirect_to session.url, allow_other_host: true
   end

--- a/src/app/controllers/customer/orders_controller.rb
+++ b/src/app/controllers/customer/orders_controller.rb
@@ -1,0 +1,5 @@
+class Customer::OrdersController < ApplicationController
+  def index
+    @customer = true
+  end
+end

--- a/src/app/controllers/customer/orders_controller.rb
+++ b/src/app/controllers/customer/orders_controller.rb
@@ -1,6 +1,7 @@
 class Customer::OrdersController < ApplicationController
+  before_action :authenticate_customer_account!
   def index
     @customer = true
-    @orders = current_customer.orders
+    @orders = current_customer.orders.order(order_date: :desc)
   end
 end

--- a/src/app/controllers/customer/orders_controller.rb
+++ b/src/app/controllers/customer/orders_controller.rb
@@ -1,5 +1,6 @@
 class Customer::OrdersController < ApplicationController
   def index
     @customer = true
+    @orders = current_customer.orders
   end
 end

--- a/src/app/controllers/webhooks/stripes_controller.rb
+++ b/src/app/controllers/webhooks/stripes_controller.rb
@@ -106,6 +106,9 @@ class Webhooks::StripesController < ApplicationController
     line_items.data.each do |line_item|
       product = Product.find_by(stripe_product_id: line_item.price.product)
 
+      # 在庫数を減らす
+      product.update(stock: product.stock - line_item.quantity)
+
       OrderItem.create(
         quantity: line_item.quantity,
         order:,

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -3,4 +3,5 @@ class Customer < ApplicationRecord
   has_many :favorite_products, dependent: :destroy
   has_one :customer_account, dependent: :destroy
   has_one :address, as: :addressable, dependent: :destroy, inverse_of: :addressable
+  has_many :orders, dependent: :destroy
 end

--- a/src/app/models/order.rb
+++ b/src/app/models/order.rb
@@ -1,22 +1,13 @@
 class Order < ApplicationRecord
   belongs_to :customer, optional: true
-  before_create :generate_order_number
+  has_many :order_items, dependent: :destroy
 
   with_options presence: true do
-    validates :order_number, uniqueness: true
-    validates :total, numericality: { only_integer: true }
+    validates :order_number, uniqueness: true, length: { is: 19 }, format: { with: /\A\d{3}-\d{7}-\d{7}\z/ }
+    validates :total, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
     validates :order_date
+    validates :receipt_url, format: { with: /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/ }
   end
 
   validates :guest_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_nil: true
-  validates_associated :customer, allow_nil: true
-
-  private
-
-  def generate_order_number
-    loop do
-      self.order_number = SecureRandom.hex(6)
-      break unless Order.exists?(order_number:)
-    end
-  end
 end

--- a/src/app/models/order.rb
+++ b/src/app/models/order.rb
@@ -1,0 +1,22 @@
+class Order < ApplicationRecord
+  belongs_to :customer, optional: true
+  before_create :generate_order_number
+
+  with_options presence: true do
+    validates :order_number, uniqueness: true
+    validates :total, numericality: { only_integer: true }
+    validates :order_date
+  end
+
+  validates :guest_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_nil: true
+  validates_associated :customer, allow_nil: true
+
+  private
+
+  def generate_order_number
+    loop do
+      self.order_number = SecureRandom.hex(6)
+      break unless Order.exists?(order_number:)
+    end
+  end
+end

--- a/src/app/models/order_item.rb
+++ b/src/app/models/order_item.rb
@@ -1,0 +1,4 @@
+class OrderItem < ApplicationRecord
+  belongs_to :order
+  belongs_to :product
+end

--- a/src/app/models/order_item.rb
+++ b/src/app/models/order_item.rb
@@ -1,4 +1,10 @@
 class OrderItem < ApplicationRecord
   belongs_to :order
   belongs_to :product
+
+  with_options presence: true do
+    validates :quantity, numericality: { only_integer: true, greater_than: 0 }
+    validates :order
+    validates :product
+  end
 end

--- a/src/app/views/customer/orders/index.html.erb
+++ b/src/app/views/customer/orders/index.html.erb
@@ -1,0 +1,66 @@
+<div class="flex-grow">
+    <!-- 購入履歴 -->
+    <div class="flex flex-col items-center pt-10 antialiased">
+        <div class="flex w-full flex-col space-y-4 py-4 md:w-4/5 lg:w-1/2">
+            <h1
+            class="py-2 text-center text-2xl font-bold md:text-start md:text-4xl"
+          >
+                購入履歴
+            </h1>
+            <!-- 商品1 -->
+            <div
+            class="mx-2 flex flex-col divide-y-2 divide-gray-300 rounded-2xl border border-black bg-white p-3 md:p-6"
+          >
+                <div class="flex flex-col justify-between pb-2 md:flex-row">
+                    <div>
+                        <p class="text-sm lg:text-base">購入日: 2024年4月25日</p>
+                        <p class="text-sm lg:text-base">合計: ¥883</p>
+                    </div>
+                    <p class="flex items-end text-sm lg:text-base">
+                        注文番号: xxx-xxxxxxx-xxxxxxx
+                    </p>
+                </div>
+                <div class="flex pt-2">
+                    <!-- 商品画像 -->
+                    <!-- TODO: 画像アップロード場所が決まったら実装する -->
+                    <div class="flex w-1/2 items-center md:w-2/5 lg:w-1/3">
+                        <%= image_tag 'sample_image.jpg', class: 'block h-1/2 rounded-lg shadow-xl md:h-auto' %>
+                    </div>
+                    <!-- 商品情報 -->
+                    <div
+                class="ml-2 mt-2 flex w-1/2 flex-col justify-center md:ml-6 md:w-full md:flex-row md:justify-between"
+              >
+                        <div class="w-full space-y-2 md:w-2/3">
+                            <a href="#">
+                                <h1
+                      class="text-lg text-sky-400 hover:text-orange-400 hover:underline"
+                    >
+                                    絵画02
+                                </h1>
+                            </a>
+                            <p class="text-sm lg:text-base">エミリオ・ヴァレンティ</p>
+                            <p class="text-sm lg:text-base">デジタル商品</p>
+                        </div>
+                        <!-- オプションボタン -->
+                        <div
+                  class="flex w-full flex-col items-center justify-center space-y-2 pt-2 md:w-1/3 md:space-y-6 md:pt-0"
+                >
+                            <button
+                    type="button"
+                    class="flex w-full justify-center rounded-full border border-gray-300 bg-white p-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:p-2 lg:text-base"
+                  >
+                                領収書を発行する
+                            </button>
+                            <button
+                    type="button"
+                    class="flex w-full justify-center rounded-full border border-gray-300 bg-white p-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:p-2 lg:text-base"
+                  >
+                                レビューを書く
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- ページネーション -->
+            <%= render 'layouts/pagenation' %>
+        </div>

--- a/src/app/views/customer/orders/index.html.erb
+++ b/src/app/views/customer/orders/index.html.erb
@@ -46,6 +46,8 @@
                                                     <p class="text-sm lg:text-base"><%= order_item.product.creator%></p>
                                                     <!-- TODO: デジタル、物理の実装ができたらこちらも実装する -->
                                                     <p class="text-sm lg:text-base">デジタル商品</p>
+                                                    <p class="text-sm lg:text-base">数量: <%= order_item.quantity%></p>
+
                                                 </div>
                                             </div>
                                         </div>

--- a/src/app/views/customer/orders/index.html.erb
+++ b/src/app/views/customer/orders/index.html.erb
@@ -7,6 +7,67 @@
           >
                 購入履歴
             </h1>
+            <% if @orders.empty? %>
+                <div class="mx-2 rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 p-3 md:p-6">
+                    <p class="text-center">購入した商品はありません</p>
+                </div>
+            <% else %>
+                <% @orders.each do |order|%>
+                    <div
+            class="mx-2 flex flex-col divide-y-2 divide-gray-300 rounded-2xl border border-black bg-white p-3 md:p-6"
+          >
+                        <div class="flex flex-col justify-between pb-2 md:flex-row">
+                            <div>
+                                <p class="text-sm lg:text-base">購入日: <%= order.order_date.strftime('%Y年%m月%d日')%></p>
+                                <p class="text-sm lg:text-base">合計: ¥<%= order.total%></p>
+                            </div>
+                            <p class="flex items-end text-sm lg:text-base">
+                                注文番号: <%= order.order_number%>
+                            </p>
+                        </div>
+                        <div class="flex pt-2">
+                            <!-- 商品画像 -->
+                            <!-- TODO: 画像アップロード場所が決まったら実装する -->
+                            <div class="flex w-1/2 items-center md:w-2/5 lg:w-1/3">
+                                <%= image_tag 'sample_image.jpg', class: 'block h-1/2 rounded-lg shadow-xl md:h-auto' %>
+                            </div>
+                            <!-- 商品情報 -->
+                            <div
+                class="ml-2 mt-2 flex w-1/2 flex-col justify-center md:ml-6 md:w-full md:flex-row md:justify-between"
+              >
+                                <div class="w-full space-y-2 md:w-2/3">
+                                    <a href="#">
+                                        <h1
+                      class="text-lg text-sky-400 hover:text-orange-400 hover:underline"
+                    >
+                                            絵画02
+                                        </h1>
+                                    </a>
+                                    <p class="text-sm lg:text-base">エミリオ・ヴァレンティ</p>
+                                    <p class="text-sm lg:text-base">デジタル商品</p>
+                                </div>
+                                <!-- オプションボタン -->
+                                <div
+                  class="flex w-full flex-col items-center justify-center space-y-2 pt-2 md:w-1/3 md:space-y-6 md:pt-0"
+                >
+                                    <button
+                    type="button"
+                    class="flex w-full justify-center rounded-full border border-gray-300 bg-white p-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:p-2 lg:text-base"
+                  >
+                                        領収書を発行する
+                                    </button>
+                                    <button
+                    type="button"
+                    class="flex w-full justify-center rounded-full border border-gray-300 bg-white p-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:p-2 lg:text-base"
+                  >
+                                        レビューを書く
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                <% end %>
+            <% end %>
             <!-- 商品1 -->
             <div
             class="mx-2 flex flex-col divide-y-2 divide-gray-300 rounded-2xl border border-black bg-white p-3 md:p-6"

--- a/src/app/views/customer/orders/index.html.erb
+++ b/src/app/views/customer/orders/index.html.erb
@@ -26,39 +26,39 @@
                             </p>
                         </div>
                         <div class="flex pt-2">
-                            <!-- 商品画像 -->
-                            <!-- TODO: 画像アップロード場所が決まったら実装する -->
-                            <div class="flex w-1/2 items-center md:w-2/5 lg:w-1/3">
-                                <%= image_tag 'sample_image.jpg', class: 'block h-1/2 rounded-lg shadow-xl md:h-auto' %>
-                            </div>
-                            <!-- 商品情報 -->
-                            <div
+                            <!--  アイテムコンテナ -->
+                            <div class="flex flex-col sm:flex-row">
+                                <!-- 各アイテムコンテナ -->
+                                <div class="flex flex-col">
+                                    <% order.order_items.each do |order_item|%>
+                                        <div class="flex mt-2">
+                                            <!-- 商品画像 -->
+                                            <!-- TODO: 画像アップロード場所が決まったら実装する -->
+                                            <div class="flex items-center md:w-2/5 lg:w-1/3">
+                                                <%= image_tag 'sample_image.jpg', class: 'block object-cover h-1/2 rounded-lg shadow-xl md:h-auto' %>
+                                            </div>
+                                            <!-- 商品情報 -->
+                                            <div
                 class="ml-2 mt-2 flex w-1/2 flex-col justify-center md:ml-6 md:w-full md:flex-row md:justify-between"
               >
-                                <div class="w-full space-y-2 md:w-2/3">
-                                    <a href="#">
-                                        <h1
-                      class="text-lg text-sky-400 hover:text-orange-400 hover:underline"
-                    >
-                                            絵画02
-                                        </h1>
-                                    </a>
-                                    <p class="text-sm lg:text-base">エミリオ・ヴァレンティ</p>
-                                    <p class="text-sm lg:text-base">デジタル商品</p>
+                                                <div class="w-full space-y-2 md:w-2/3">
+                                                    <%= link_to order_item.product.name, order_item.product, class: 'text-lg text-sky-400 hover:text-orange-400 hover:underline' %>
+                                                    <p class="text-sm lg:text-base"><%= order_item.product.creator%></p>
+                                                    <!-- TODO: デジタル、物理の実装ができたらこちらも実装する -->
+                                                    <p class="text-sm lg:text-base">デジタル商品</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    <% end %>
                                 </div>
                                 <!-- オプションボタン -->
                                 <div
-                  class="flex w-full flex-col items-center justify-center space-y-2 pt-2 md:w-1/3 md:space-y-6 md:pt-0"
+                  class="flex w-full flex-col mt-2 pt-2 md:pt-0"
                 >
+                                    <%= link_to '領収書を発行する', order.receipt_url, target: :_blank, rel: "noopener noreferrer" , class: 'flex w-full justify-center rounded-full border border-gray-300 bg-white p-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:p-2 lg:text-base' %>
                                     <button
                     type="button"
-                    class="flex w-full justify-center rounded-full border border-gray-300 bg-white p-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:p-2 lg:text-base"
-                  >
-                                        領収書を発行する
-                                    </button>
-                                    <button
-                    type="button"
-                    class="flex w-full justify-center rounded-full border border-gray-300 bg-white p-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:p-2 lg:text-base"
+                    class="mt-2 flex w-full justify-center rounded-full border border-gray-300 bg-white p-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:p-2 lg:text-base"
                   >
                                         レビューを書く
                                     </button>
@@ -68,60 +68,6 @@
                     </div>
                 <% end %>
             <% end %>
-            <!-- 商品1 -->
-            <div
-            class="mx-2 flex flex-col divide-y-2 divide-gray-300 rounded-2xl border border-black bg-white p-3 md:p-6"
-          >
-                <div class="flex flex-col justify-between pb-2 md:flex-row">
-                    <div>
-                        <p class="text-sm lg:text-base">購入日: 2024年4月25日</p>
-                        <p class="text-sm lg:text-base">合計: ¥883</p>
-                    </div>
-                    <p class="flex items-end text-sm lg:text-base">
-                        注文番号: xxx-xxxxxxx-xxxxxxx
-                    </p>
-                </div>
-                <div class="flex pt-2">
-                    <!-- 商品画像 -->
-                    <!-- TODO: 画像アップロード場所が決まったら実装する -->
-                    <div class="flex w-1/2 items-center md:w-2/5 lg:w-1/3">
-                        <%= image_tag 'sample_image.jpg', class: 'block h-1/2 rounded-lg shadow-xl md:h-auto' %>
-                    </div>
-                    <!-- 商品情報 -->
-                    <div
-                class="ml-2 mt-2 flex w-1/2 flex-col justify-center md:ml-6 md:w-full md:flex-row md:justify-between"
-              >
-                        <div class="w-full space-y-2 md:w-2/3">
-                            <a href="#">
-                                <h1
-                      class="text-lg text-sky-400 hover:text-orange-400 hover:underline"
-                    >
-                                    絵画02
-                                </h1>
-                            </a>
-                            <p class="text-sm lg:text-base">エミリオ・ヴァレンティ</p>
-                            <p class="text-sm lg:text-base">デジタル商品</p>
-                        </div>
-                        <!-- オプションボタン -->
-                        <div
-                  class="flex w-full flex-col items-center justify-center space-y-2 pt-2 md:w-1/3 md:space-y-6 md:pt-0"
-                >
-                            <button
-                    type="button"
-                    class="flex w-full justify-center rounded-full border border-gray-300 bg-white p-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:p-2 lg:text-base"
-                  >
-                                領収書を発行する
-                            </button>
-                            <button
-                    type="button"
-                    class="flex w-full justify-center rounded-full border border-gray-300 bg-white p-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700 md:p-2 lg:text-base"
-                  >
-                                レビューを書く
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </div>
             <!-- ページネーション -->
             <%= render 'layouts/pagenation' %>
         </div>

--- a/src/app/views/layouts/customer/_navbar.html.erb
+++ b/src/app/views/layouts/customer/_navbar.html.erb
@@ -77,7 +77,7 @@
                 <a href="#" class="block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">チャット</a>
               </li>
               <li>
-                <a href="#" class="block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">購入履歴</a>
+                <%= link_to '購入履歴', orders_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
               </li>
               <li>
                 <a href="#" class="block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">アカウント情報</a>

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -38,6 +38,8 @@ Rails.application.routes.draw do
     end
     resource :checkout, only: %i[create]
     get 'checkout/success', to: 'checkouts#success'
+
+    resources :orders, only: [:index]
   end
 
   namespace :webhooks do

--- a/src/db/migrate/20240527081952_create_orders.rb
+++ b/src/db/migrate/20240527081952_create_orders.rb
@@ -1,11 +1,12 @@
 class CreateOrders < ActiveRecord::Migration[7.1]
   def change
     create_table :orders do |t|
-      t.string :order_number
+      t.string :order_number, index: { unique: true}
       t.integer :total
       t.datetime :order_date
       t.string :guest_email
-      t.references :customer, null: false, foreign_key: true
+      t.string :receipt_url
+      t.references :customer, null: true, foreign_key: true
 
       t.timestamps
     end

--- a/src/db/migrate/20240527081952_create_orders.rb
+++ b/src/db/migrate/20240527081952_create_orders.rb
@@ -1,0 +1,13 @@
+class CreateOrders < ActiveRecord::Migration[7.1]
+  def change
+    create_table :orders do |t|
+      t.string :order_number
+      t.integer :total
+      t.datetime :order_date
+      t.string :guest_email
+      t.references :customer, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/src/db/migrate/20240527082654_create_order_items.rb
+++ b/src/db/migrate/20240527082654_create_order_items.rb
@@ -1,0 +1,11 @@
+class CreateOrderItems < ActiveRecord::Migration[7.1]
+  def change
+    create_table :order_items do |t|
+      t.integer :quantity
+      t.references :order, null: false, foreign_key: true
+      t.references :product, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_26_084641) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_27_082654) do
   create_table "addresses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "zip_code"
     t.string "state"
@@ -84,6 +84,27 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_26_084641) do
     t.index ["product_id"], name: "index_favorite_products_on_product_id"
   end
 
+  create_table "order_items", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "quantity"
+    t.bigint "order_id", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_order_items_on_order_id"
+    t.index ["product_id"], name: "index_order_items_on_product_id"
+  end
+
+  create_table "orders", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "order_number"
+    t.integer "total"
+    t.datetime "order_date"
+    t.string "guest_email"
+    t.bigint "customer_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_orders_on_customer_id"
+  end
+
   create_table "product_categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -118,6 +139,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_26_084641) do
   add_foreign_key "customer_accounts", "customers"
   add_foreign_key "favorite_products", "customers"
   add_foreign_key "favorite_products", "products"
+  add_foreign_key "order_items", "orders"
+  add_foreign_key "order_items", "products"
+  add_foreign_key "orders", "customers"
   add_foreign_key "products", "product_categories"
   add_foreign_key "wish_products", "customers"
   add_foreign_key "wish_products", "products"

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -99,10 +99,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_27_082654) do
     t.integer "total"
     t.datetime "order_date"
     t.string "guest_email"
-    t.bigint "customer_id", null: false
+    t.string "receipt_url"
+    t.bigint "customer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["customer_id"], name: "index_orders_on_customer_id"
+    t.index ["order_number"], name: "index_orders_on_order_number", unique: true
   end
 
   create_table "product_categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/src/spec/factories/order_items.rb
+++ b/src/spec/factories/order_items.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :order_item do
+    quantity { 1 }
+    order { nil }
+    product { nil }
+  end
+end

--- a/src/spec/factories/order_items.rb
+++ b/src/spec/factories/order_items.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :order_item do
     quantity { 1 }
-    order { nil }
-    product { nil }
+    order
+    product
   end
 end

--- a/src/spec/factories/orders.rb
+++ b/src/spec/factories/orders.rb
@@ -1,9 +1,19 @@
 FactoryBot.define do
   factory :order do
-    order_number { "MyString" }
-    total { 1 }
-    order_date { "2024-05-27 17:19:52" }
-    guest_email { "MyString" }
+    order_number { '123-1234567-1234567' }
+    total { 0 }
+    order_date { Time.current }
+    guest_email { 'test@gmail.com' }
     customer { nil }
+    receipt_url { 'https://receipt.com' }
+
+    trait :with_customer do
+      guest_email { nil }
+      customer
+    end
+  end
+
+  factory :login_user_order, parent: :order do
+    customer
   end
 end

--- a/src/spec/factories/orders.rb
+++ b/src/spec/factories/orders.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :order do
+    order_number { "MyString" }
+    total { 1 }
+    order_date { "2024-05-27 17:19:52" }
+    guest_email { "MyString" }
+    customer { nil }
+  end
+end

--- a/src/spec/models/order_item_spec.rb
+++ b/src/spec/models/order_item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OrderItem, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/src/spec/models/order_item_spec.rb
+++ b/src/spec/models/order_item_spec.rb
@@ -1,5 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe OrderItem, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:order_item) { create(:order_item) }
+
+  it 'is valid with quantity, order, product' do
+    expect(order_item).to be_valid
+  end
+
+  it 'is invalid without quantity' do
+    order_item.quantity = nil
+    order_item.valid?
+    expect(order_item.errors[:quantity]).to include('を入力してください')
+  end
+
+  it 'is invalid without order' do
+    order_item.order = nil
+    order_item.valid?
+    expect(order_item.errors[:order]).to include('を入力してください')
+  end
+
+  it 'is invalid without product' do
+    order_item.product = nil
+    order_item.valid?
+    expect(order_item.errors[:product]).to include('を入力してください')
+  end
 end

--- a/src/spec/models/order_spec.rb
+++ b/src/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/src/spec/models/order_spec.rb
+++ b/src/spec/models/order_spec.rb
@@ -1,5 +1,72 @@
 require 'rails_helper'
 
 RSpec.describe Order, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:order) { create(:order) }
+  let(:login_user_order) { create(:login_user_order) }
+
+  context 'when order is a guest order' do
+    it 'is valid with a order_number, total, order_date, ,guest_email, receipt_url' do
+      expect(order).to be_valid
+    end
+
+    it 'is invalid without an order_number' do
+      order.order_number = nil
+      order.valid?
+      expect(order.errors[:order_number]).to include('を入力してください')
+    end
+
+    it 'is invalid without a total' do
+      order.total = nil
+      order.valid?
+      expect(order.errors[:total]).to include('を入力してください')
+    end
+
+    it 'is invalid without a order_date' do
+      order.order_date = nil
+      order.valid?
+      expect(order.errors[:order_date]).to include('を入力してください')
+    end
+
+    it 'is invalid with a invalid guest_email' do
+      order.guest_email = '無効な文字列'
+      order.valid?
+      expect(order.errors[:guest_email]).to include('は不正な値です')
+    end
+
+    it 'is invalid without a receipt_url' do
+      order.receipt_url = nil
+      order.valid?
+      expect(order.errors[:receipt_url]).to include('は不正な値です')
+    end
+  end
+
+  context 'when order is associated with a customer' do
+    it 'is valid with a order_number, total, order_date, customer, receipt_url' do
+      expect(login_user_order).to be_valid
+    end
+
+    it 'is invalid without an order_number' do
+      login_user_order.order_number = nil
+      login_user_order.valid?
+      expect(login_user_order.errors[:order_number]).to include('を入力してください')
+    end
+
+    it 'is invalid without a total' do
+      login_user_order.total = nil
+      login_user_order.valid?
+      expect(login_user_order.errors[:total]).to include('を入力してください')
+    end
+
+    it 'is invalid without a order_date' do
+      login_user_order.order_date = nil
+      login_user_order.valid?
+      expect(login_user_order.errors[:order_date]).to include('を入力してください')
+    end
+
+    it 'is invalid without a receipt_url' do
+      login_user_order.receipt_url = nil
+      login_user_order.valid?
+      expect(login_user_order.errors[:receipt_url]).to include('を入力してください')
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- 購入履歴を閲覧できるページの作成
- 購入履歴ページからデジタル領収書を保存できる機能の実装

### Issue
[【Sprint3】デジタル領収書の保存機能の実装(購入履歴ページの作成含む)](https://github.com/recursion-backend-projects/E-Commerce-Webapp-with-Stripe-Sync/issues/16)

## 目的
ユーザーが商品を購入後、注文履歴の閲覧とデジタル領収書を保存できるようにするため

## やったこと
- 注文履歴ページの作成
- Orderモデル（テーブル）、OrderItemモデル（テーブル）の作成
- Ordersコントローラーの作成
- 在庫数を減らすロジックの実装
- Order、OrderItemのバリデーション
- Order、OrderItemの簡単なテストケース
- [ER図](https://github.com/recursion-backend-projects/dev-log/blob/main/er.md)の修正

## やっていないこと
- デジタル領収書をPDFで保存すること

## 確認方法

1. ログインする
2. カートに商品を入れる
3. レジに進んで、決済を行う
4. 購入履歴ページを開いて、購入日や合計、購入した商品などが反映されているか確認
5. 「領収書を発行する」ボタンを押すと、stripeが用意した領収書が閲覧できるか確認
6. http://localhost:3000/admin/products などで購入した商品の在庫数が減っているか確認

## レビューで見てほしいこと、不安に思っていること
- 購入履歴が反映されるかどうか
- 領収書が閲覧できるかどうか

stripeが用意する領収書のURLの有効期限はセキュリティ対策として、発行されてから[30日で切れる](https://docs.stripe.com/receipts?locale=ja-JP)ようです。ただ、有効期限が切れた領収書のリンクでは、顧客は元のメールアドレスを入力して、そのアドレスに領収書を再送信できるようです。

以上のことから、以下の2つの選択肢があると思いました。
- 選択肢1
  - 領収書のURLをそのまま提供するのではなく、バックエンド側でPDFに変換してAmazon S3に保存する。そのS3上のURLを顧客に提供する

- 選択肢2
  - もし有効期限が切れた後に領収書が必要な場合は、リンク切れを踏んでもらって、メールアドレスを入力してもらい、そのアドレスにStripeから領収書を再送信する

今回はテスト用のEコマースアプリなので、購入して30日以上経過してから領収書を確認するというケースがほぼ無いと思い、選択肢2の方法を採用しています！

## その他
今回の実装にあたり、[ER図](https://github.com/recursion-backend-projects/dev-log/blob/main/er.md)から、Receiptテーブルを削除したり、Orderテーブルにguest_emailカラムを追加したりなど、修正を行っています。