### PR TITLE
Feature/#42 edit account

### DIFF
--- a/src/.rubocop.yml
+++ b/src/.rubocop.yml
@@ -76,6 +76,16 @@ Layout/LineLength:
 RSpecRails/InferredSpecType:
   Enabled: false
 
+# 厳密にテストしたい場合に複数条件を入れるのはよいかと
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecmultipleexpectations
+RSpec/MultipleExpectations:
+  Enabled: false
+
+# 厳密にテストしたい場合に多少長くなるのはしょうがない
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecexamplelength
+RSpec/ExampleLength:
+  Max: 30
+
 # ============================================================
 # Rails
 # ============================================================

--- a/src/.rubocop.yml
+++ b/src/.rubocop.yml
@@ -93,8 +93,9 @@ Metrics/BlockLength:
     - "config/routes.rb"
 
 Naming/VariableNumber:
+  EnforcedStyle: snake_case
   Exclude:
-    - "spec/factories/customers.rb"
+    - "app/controllers/customer/accounts_controller.rb" #　customer.updateの引数で引っかかるので除外
 
 Metrics/ClassLength:
   Max: 120

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -92,3 +92,5 @@ gem 'rails-i18n'
 gem 'aws-sdk-s3', require: false
 
 gem 'active_storage_validations'
+
+gem "active_hash", "~> 3.3"

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -93,4 +93,4 @@ gem 'aws-sdk-s3', require: false
 
 gem 'active_storage_validations'
 
-gem "active_hash", "~> 3.3"
+gem 'active_hash', '~> 3.3'

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_hash (3.3.1)
+      activesupport (>= 5.0.0)
     active_storage_validations (1.1.4)
       activejob (>= 5.2.0)
       activemodel (>= 5.2.0)
@@ -365,6 +367,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_hash (~> 3.3)
   active_storage_validations
   aws-sdk-s3
   bootsnap

--- a/src/app/controllers/customer/accounts_controller.rb
+++ b/src/app/controllers/customer/accounts_controller.rb
@@ -1,4 +1,6 @@
 class Customer::AccountsController < ApplicationController
+  before_action :authenticate_customer_account!
+
   def show
     @customer = true
   end
@@ -12,10 +14,11 @@ class Customer::AccountsController < ApplicationController
     @customer = true
     @current_customer = current_customer
     if @current_customer.update(customer_params)
-      # Stripe::Customer.update(@current_customer.stripe_customer_id,
-      #                         shipping: { name: @current_customer.customer_account.shipping_name,
-      #                                     address: { country: 'JP', postal_code: @current_customer.address.zip_code, state: @current_customer.prefecture&.name,
-      #                                                line1: @current_customer.address.street_address, line2: @current_customer.address.street_address_2 } })
+      Stripe::Customer.update(@current_customer.stripe_customer_id,
+                              shipping: { name: @current_customer.customer_account.shipping_name,
+                                          address: { country: 'JP', postal_code: @current_customer.address.zip_code,
+                                                     state: @current_customer.address.prefecture&.name,
+                                                     line1: @current_customer.address.street_address, line2: @current_customer.address.street_address_2 } })
       redirect_to account_path, notice: 'アカウント情報が更新されました'
     else
       render :edit

--- a/src/app/controllers/customer/accounts_controller.rb
+++ b/src/app/controllers/customer/accounts_controller.rb
@@ -1,0 +1,10 @@
+class Customer::AccountsController < ApplicationController
+  def show
+    @customer = true
+  end
+
+  def edit
+    @customer = true
+    @current_customer = current_customer
+  end
+end

--- a/src/app/controllers/customer/accounts_controller.rb
+++ b/src/app/controllers/customer/accounts_controller.rb
@@ -7,4 +7,25 @@ class Customer::AccountsController < ApplicationController
     @customer = true
     @current_customer = current_customer
   end
+
+  def update
+    @customer = true
+    @current_customer = current_customer
+    if @current_customer.update(customer_params)
+      # Stripe::Customer.update(@current_customer.stripe_customer_id,
+      #                         shipping: { name: @current_customer.customer_account.shipping_name,
+      #                                     address: { country: 'JP', postal_code: @current_customer.address.zip_code, state: @current_customer.prefecture&.name,
+      #                                                line1: @current_customer.address.street_address, line2: @current_customer.address.street_address_2 } })
+      redirect_to account_path, notice: 'アカウント情報が更新されました'
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def customer_params
+    params.require(:customer).permit(customer_account_attributes: %i[id user_name shipping_name email phone_number],
+                                     address_attributes: %i[id zip_code prefecture_id street_address street_address_2])
+  end
 end

--- a/src/app/models/address.rb
+++ b/src/app/models/address.rb
@@ -1,3 +1,6 @@
 class Address < ApplicationRecord
   belongs_to :addressable, polymorphic: true
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :prefecture
 end

--- a/src/app/models/address.rb
+++ b/src/app/models/address.rb
@@ -3,4 +3,11 @@ class Address < ApplicationRecord
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :prefecture
+
+  with_options allow_blank: true do
+    validates :zip_code, format: { with: /\A\d{3}-\d{4}\z/, message: 'の形式が不正です（例:123-4567）' }
+    validates :prefecture_id, numericality: { only_integer: true, in: 1..47 }
+    validates :street_address, length: { maximum: 200 }
+    validates :street_address_2, length: { maximum: 200 }
+  end
 end

--- a/src/app/models/customer.rb
+++ b/src/app/models/customer.rb
@@ -6,4 +6,7 @@ class Customer < ApplicationRecord
   has_one :customer_account, dependent: :destroy
   has_one :address, as: :addressable, dependent: :destroy, inverse_of: :addressable
   has_many :orders, dependent: :destroy
+
+  accepts_nested_attributes_for :customer_account
+  accepts_nested_attributes_for :address
 end

--- a/src/app/models/customer_account.rb
+++ b/src/app/models/customer_account.rb
@@ -9,6 +9,14 @@ class CustomerAccount < ApplicationRecord
     with: /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i
   }, on: :create
 
+  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP, message: 'の形式が不正です' }
+
+  with_options allow_blank: true do
+    validates :user_name, length: { in: 3..20 }, format: { with: /\A[a-zA-Z0-9_]+\z/, message: 'は英数字とアンダースコアのみ使用できます' }
+    validates :shipping_name, length: { maximum: 50 }
+    validates :phone_number, format: { with: /\A(090|080|070)-\d{4}-\d{4}\z/, message: 'の形式が不正です' }
+  end
+
   belongs_to :customer
 
   # Eメール認証後に実行するdeviseの関数をオーバーライド

--- a/src/app/models/prefecture.rb
+++ b/src/app/models/prefecture.rb
@@ -1,0 +1,20 @@
+class Prefecture < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '北海道' }, { id: 2, name: '青森県' }, { id: 3, name: '岩手県' },
+    { id: 4, name: '宮城県' }, { id: 5, name: '秋田県' }, { id: 6, name: '山形県' },
+    { id: 7, name: '福島県' }, { id: 8, name: '茨城県' }, { id: 9, name: '栃木県' },
+    { id: 10, name: '群馬県' }, { id: 11, name: '埼玉県' }, { id: 12, name: '千葉県' },
+    { id: 13, name: '東京都' }, { id: 14, name: '神奈川県' }, { id: 15, name: '新潟県' },
+    { id: 16, name: '富山県' }, { id: 17, name: '石川県' }, { id: 18, name: '福井県' },
+    { id: 19, name: '山梨県' }, { id: 20, name: '長野県' }, { id: 21, name: '岐阜県' },
+    { id: 22, name: '静岡県' }, { id: 23, name: '愛知県' }, { id: 24, name: '三重県' },
+    { id: 25, name: '滋賀県' }, { id: 26, name: '京都府' }, { id: 27, name: '大阪府' },
+    { id: 28, name: '兵庫県' }, { id: 29, name: '奈良県' }, { id: 30, name: '和歌山県' },
+    { id: 31, name: '鳥取県' }, { id: 32, name: '島根県' }, { id: 33, name: '岡山県' },
+    { id: 34, name: '広島県' }, { id: 35, name: '山口県' }, { id: 36, name: '徳島県' },
+    { id: 37, name: '香川県' }, { id: 38, name: '愛媛県' }, { id: 39, name: '高知県' },
+    { id: 40, name: '福岡県' }, { id: 41, name: '佐賀県' }, { id: 42, name: '長崎県' },
+    { id: 43, name: '熊本県' }, { id: 44, name: '大分県' }, { id: 45, name: '宮崎県' },
+    { id: 46, name: '鹿児島県' }, { id: 47, name: '沖縄県' }
+  ]
+end

--- a/src/app/views/customer/accounts/edit.html.erb
+++ b/src/app/views/customer/accounts/edit.html.erb
@@ -11,7 +11,7 @@
             </h1>
             <!-- 入力フォーム -->
             <%= form_with model: @current_customer, url: '/account', method: :patch, data:{turbo: false}, class: 'space-y-4 rounded-xl border border-gray-200 bg-white p-4 shadow-xl' do |form| %>
-            <%= render 'shared/error_messages', model: form.object %>
+                <%= render 'shared/error_messages', model: form.object %>
                 <h2 class="text-xl font-bold md:text-2xl">1. 基本情報</h2>
                 <%= form.fields_for :customer_account do |customer_account_form|%>
                     <div>
@@ -55,8 +55,26 @@
                 <h2 class="text-xl font-bold md:text-2xl">3. お支払い方法</h2>
                 <p class="text-base text-gray-500 md:text-lg">
                     デモサイトのため、金銭のやり取りは発生しません。<br />
-                    商品ご購入時に、テスト用のカードデータをご用意致します。
+                    商品ご購入時には、以下のカード情報を手動で入力してください。
                 </p>
+                <div>
+                    <p>カード番号</p>
+                    <p class="w-full rounded border border-gray-300 p-2">
+                        4242 4242 4242 4242
+                    </p>
+                </div>
+                <div>
+                    <p>有効期限(有効な将来の日付)</p>
+                    <p class="w-full rounded border border-gray-300 p-2">
+                        12/34
+                    </p>
+                </div>
+                <div>
+                    <p>セキュリティーコード(任意の3桁)</p>
+                    <p class="w-full rounded border border-gray-300 p-2">
+                        123
+                    </p>
+                </div>
                 <div class="flex flex-row justify-between py-4">
                     <%= link_to 'キャンセル', account_path, class: 'rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700' %>
                     <%= form.submit '保存する', class: 'rounded-lg bg-yellow-400 p-1.5 px-4 py-2 hover:bg-yellow-500 hover:cursor-pointer' %>

--- a/src/app/views/customer/accounts/edit.html.erb
+++ b/src/app/views/customer/accounts/edit.html.erb
@@ -1,0 +1,64 @@
+<!-- アカウント情報の編集 -->
+<div class="mb-10 flex flex-col items-center pt-10 antialiased">
+    <div class="flex w-full flex-col py-4 md:w-1/2 lg:w-1/3">
+        <div
+            class="container items-center justify-center space-y-4 px-6 md:pl-0"
+          >
+            <h1
+              class="text-center text-2xl font-bold md:text-start md:text-4xl"
+            >
+                アカウント情報の編集
+            </h1>
+            <!-- 入力フォーム -->
+            <%= form_with model: @current_customer, url: '/account', method: :patch, class: 'space-y-4 rounded-xl border border-gray-200 bg-white p-4 shadow-xl' do |form| %>
+                <h2 class="text-xl font-bold md:text-2xl">1. 基本情報</h2>
+                <%= fields_for :customer_account, @current_customer.customer_account do |customer_account_form|%>
+                    <div>
+                        <%= customer_account_form.label :user_name, 'ユーザー名'%>
+                        <%= customer_account_form.text_field :user_name, placeholder: 'ユーザー名', class: 'w-full rounded border border-gray-300 p-2',value: @current_customer.customer_account.user_name, required: true %>
+                    </div>
+                    <div>
+                        <%= customer_account_form.label :shipping_name, '氏名'%>
+                        <%= customer_account_form.text_field :shipping_name, placeholder: 'カード保有者の名前', class: 'w-full rounded border border-gray-300 p-2',value: @current_customer.customer_account.shipping_name%>
+                    </div>
+                    <div>
+                        <%= customer_account_form.label :email, 'メールアドレス'%>
+                        <%= customer_account_form.text_field :email, placeholder: 'email@example.com', class: 'w-full rounded border border-gray-300 p-2',value: @current_customer.customer_account.email, required: true %>
+                    </div>
+                    <div>
+                        <%= customer_account_form.label :phone_number, '電話番号'%>
+                        <%= customer_account_form.text_field :phone_number, placeholder: '123-4567-8901', class: 'w-full rounded border border-gray-300 p-2',value: @current_customer.customer_account.phone_number%>
+                    </div>
+                <% end %>
+                <h2 class="text-xl font-bold md:text-2xl">2. お届け先</h2>
+                <%= fields_for :customer_account, @current_customer.address do |address_form|%>
+                    <div>
+                        <%= address_form.label :zip_code, '郵便番号'%>
+                        <%= address_form.text_field :zip_code, placeholder: '123-4567', class: 'w-full rounded border border-gray-300 p-2' ,value: @current_customer.address.zip_code %>
+                    </div>
+                    <div>
+                        <%= address_form.label :prefecture, '都道府県'%>
+                        <%= address_form.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank: "選択する"}, class: 'w-full block rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500'%>
+                    </div>
+                    <div>
+                        <%= address_form.label :street_address, '住所(1行目)'%>
+                        <%= address_form.text_field :street_address, placeholder: '○○市○○町1-2-3', class: 'w-full rounded border border-gray-300 p-2' ,value: @current_customer.address.street_address %>
+                    </div>
+                    <div>
+                        <%= address_form.label :street_address_2, '住所(2行目)'%>
+                        <%= address_form.text_field :street_address_2, placeholder: '○○マンション10', class: 'w-full rounded border border-gray-300 p-2' ,value: @current_customer.address.street_address_2 %>
+                    </div>
+                <% end %>
+                <h2 class="text-xl font-bold md:text-2xl">3. お支払い方法</h2>
+                <p class="text-base text-gray-500 md:text-lg">
+                    デモサイトのため、金銭のやり取りは発生しません。<br />
+                    商品ご購入時に、テスト用のカードデータをご用意致します。
+                </p>
+                <div class="flex flex-row justify-between py-4">
+                    <%= link_to 'キャンセル', account_path, class: 'rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700' %>
+                    <%= form.submit '保存する', class: 'rounded-lg bg-yellow-400 p-1.5 px-4 py-2 hover:bg-yellow-500' %>
+                </div>
+            <% end %>
+        </div>
+    </div>
+</div>

--- a/src/app/views/customer/accounts/edit.html.erb
+++ b/src/app/views/customer/accounts/edit.html.erb
@@ -10,16 +10,17 @@
                 アカウント情報の編集
             </h1>
             <!-- 入力フォーム -->
-            <%= form_with model: @current_customer, url: '/account', method: :patch, class: 'space-y-4 rounded-xl border border-gray-200 bg-white p-4 shadow-xl' do |form| %>
+            <%= form_with model: @current_customer, url: '/account', method: :patch, data:{turbo: false}, class: 'space-y-4 rounded-xl border border-gray-200 bg-white p-4 shadow-xl' do |form| %>
+            <%= render 'shared/error_messages', model: form.object %>
                 <h2 class="text-xl font-bold md:text-2xl">1. 基本情報</h2>
-                <%= fields_for :customer_account, @current_customer.customer_account do |customer_account_form|%>
+                <%= form.fields_for :customer_account do |customer_account_form|%>
                     <div>
                         <%= customer_account_form.label :user_name, 'ユーザー名'%>
-                        <%= customer_account_form.text_field :user_name, placeholder: 'ユーザー名', class: 'w-full rounded border border-gray-300 p-2',value: @current_customer.customer_account.user_name, required: true %>
+                        <%= customer_account_form.text_field :user_name, placeholder: '3~20文字以内の英数字またはアンダースコア', class: 'w-full rounded border border-gray-300 p-2',value: @current_customer.customer_account.user_name%>
                     </div>
                     <div>
                         <%= customer_account_form.label :shipping_name, '氏名'%>
-                        <%= customer_account_form.text_field :shipping_name, placeholder: 'カード保有者の名前', class: 'w-full rounded border border-gray-300 p-2',value: @current_customer.customer_account.shipping_name%>
+                        <%= customer_account_form.text_field :shipping_name, placeholder: '配達先住所の氏名', class: 'w-full rounded border border-gray-300 p-2',value: @current_customer.customer_account.shipping_name%>
                     </div>
                     <div>
                         <%= customer_account_form.label :email, 'メールアドレス'%>
@@ -31,7 +32,7 @@
                     </div>
                 <% end %>
                 <h2 class="text-xl font-bold md:text-2xl">2. お届け先</h2>
-                <%= fields_for :customer_account, @current_customer.address do |address_form|%>
+                <%= form.fields_for :address do |address_form|%>
                     <div>
                         <%= address_form.label :zip_code, '郵便番号'%>
                         <%= address_form.text_field :zip_code, placeholder: '123-4567', class: 'w-full rounded border border-gray-300 p-2' ,value: @current_customer.address.zip_code %>
@@ -39,6 +40,8 @@
                     <div>
                         <%= address_form.label :prefecture, '都道府県'%>
                         <%= address_form.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank: "選択する"}, class: 'w-full block rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500'%>
+                    </div>
+                    <div>
                     </div>
                     <div>
                         <%= address_form.label :street_address, '住所(1行目)'%>
@@ -56,7 +59,7 @@
                 </p>
                 <div class="flex flex-row justify-between py-4">
                     <%= link_to 'キャンセル', account_path, class: 'rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-700' %>
-                    <%= form.submit '保存する', class: 'rounded-lg bg-yellow-400 p-1.5 px-4 py-2 hover:bg-yellow-500' %>
+                    <%= form.submit '保存する', class: 'rounded-lg bg-yellow-400 p-1.5 px-4 py-2 hover:bg-yellow-500 hover:cursor-pointer' %>
                 </div>
             <% end %>
         </div>

--- a/src/app/views/customer/accounts/show.html.erb
+++ b/src/app/views/customer/accounts/show.html.erb
@@ -1,0 +1,75 @@
+<!-- アカウント情報 -->
+<div class="mb-10 flex flex-col items-center pt-10 antialiased">
+    <div class="flex w-full flex-col py-4 md:w-1/2 lg:w-1/3">
+        <div
+            class="container items-center justify-center space-y-4 px-6 md:pl-0"
+          >
+            <h1
+              class="text-center text-2xl font-bold md:text-start md:text-4xl"
+            >
+                アカウント情報
+            </h1>
+            <p class="text-base text-gray-500 md:text-lg">
+                アカウント情報は、商品ご購入時の自動入力に利用されます
+            </p>
+            <div
+              class="space-y-4 rounded-xl border border-gray-200 bg-white p-4 shadow-xl"
+            >
+                <div class="flex justify-between">
+                    <h2 class="text-xl font-bold md:text-2xl">1. 基本情報</h2>
+                    <%= link_to '編集する', edit_account_path, class: 'mr-2 text-sky-400 hover:text-orange-400 hover:underline' %>
+                </div>
+                <div>
+                    <p>ユーザー名</p>
+                    <p class="w-full rounded border border-gray-300 p-2">UserA</p>
+                </div>
+                <div>
+                    <p>氏名</p>
+                    <p class="w-full rounded border border-gray-300 p-2">
+                        FULL NAME
+                    </p>
+                </div>
+                <div>
+                    <p>メールアドレス</p>
+                    <p class="w-full rounded border border-gray-300 p-2">
+                        email@example.com
+                    </p>
+                </div>
+                <div>
+                    <p>電話番号</p>
+                    <p class="w-full rounded border border-gray-300 p-2">
+                        123-4567-8901
+                    </p>
+                </div>
+                <h2 class="text-xl font-bold md:text-2xl">2. お届け先</h2>
+                <p for="zip-code-front">郵便番号</p>
+                <div class="flex">
+                    <p class="w-1/3 rounded border border-gray-300 p-2">123</p>
+                    <p class="px-3 py-2">ー</p>
+                    <p class="w-1/3 rounded border border-gray-300 p-2">4567</p>
+                </div>
+                <div>
+                    <p class="ml-1 block text-lg text-gray-900">都道府県</p>
+                    <p class="w-1/3 rounded border border-gray-300 p-2">北海道</p>
+                </div>
+                <div>
+                    <p>住所(1行目)</p>
+                    <p class="w-full rounded border border-gray-300 p-2">
+                        xx市oo町12-3
+                    </p>
+                </div>
+                <div>
+                    <p>住所(2行目)</p>
+                    <p class="w-full rounded border border-gray-300 p-2">
+                        xxマンション123
+                    </p>
+                </div>
+                <h2 class="text-xl font-bold md:text-2xl">3. お支払い方法</h2>
+                <p class="text-base text-gray-500 md:text-lg">
+                    デモサイトのため、金銭のやり取りは発生しません。<br />
+                    商品ご購入時に、テスト用のカードデータをご用意致します。
+                </p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/views/customer/accounts/show.html.erb
+++ b/src/app/views/customer/accounts/show.html.erb
@@ -66,8 +66,26 @@
                 <h2 class="text-xl font-bold md:text-2xl">3. お支払い方法</h2>
                 <p class="text-base text-gray-500 md:text-lg">
                     デモサイトのため、金銭のやり取りは発生しません。<br />
-                    商品ご購入時に、テスト用のカードデータをご用意致します。
+                    商品ご購入時には、以下のカード情報を手動で入力してください。
                 </p>
+                <div>
+                    <p>カード番号</p>
+                    <p class="w-full rounded border border-gray-300 p-2">
+                        4242 4242 4242 4242
+                    </p>
+                </div>
+                <div>
+                    <p>有効期限(有効な将来の日付)</p>
+                    <p class="w-full rounded border border-gray-300 p-2">
+                        12/34
+                    </p>
+                </div>
+                <div>
+                    <p>セキュリティーコード(任意の3桁)</p>
+                    <p class="w-full rounded border border-gray-300 p-2">
+                        123
+                    </p>
+                </div>
             </div>
         </div>
     </div>

--- a/src/app/views/customer/accounts/show.html.erb
+++ b/src/app/views/customer/accounts/show.html.erb
@@ -52,12 +52,6 @@
                     <p class="w-full rounded border border-gray-300 p-2"><%= @current_customer.address.prefecture.blank? ? '---': @current_customer.address.prefecture.name%></p>
                 </div>
                 <div>
-                    <p>市区町村</p>
-                    <p class="w-full rounded border border-gray-300 p-2">
-                        ---
-                    </p>
-                </div>
-                <div>
                     <p>住所(1行目)</p>
                     <p class="w-full rounded border border-gray-300 p-2">
                         <%= @current_customer.address.street_address.blank? ? '---': @current_customer.address.street_address%>

--- a/src/app/views/customer/accounts/show.html.erb
+++ b/src/app/views/customer/accounts/show.html.erb
@@ -1,3 +1,4 @@
+<%= render 'layouts/flash' %>
 <!-- アカウント情報 -->
 <div class="mb-10 flex flex-col items-center pt-10 antialiased">
     <div class="flex w-full flex-col py-4 md:w-1/2 lg:w-1/3">
@@ -21,47 +22,51 @@
                 </div>
                 <div>
                     <p>ユーザー名</p>
-                    <p class="w-full rounded border border-gray-300 p-2">UserA</p>
+                    <p class="w-full rounded border border-gray-300 p-2"><%= @current_customer.customer_account.user_name.blank? ? '---': @current_customer.customer_account.user_name%></p>
                 </div>
                 <div>
                     <p>氏名</p>
                     <p class="w-full rounded border border-gray-300 p-2">
-                        FULL NAME
+                        <%= @current_customer.customer_account.shipping_name.blank? ? '---': @current_customer.customer_account.shipping_name %>
                     </p>
                 </div>
                 <div>
                     <p>メールアドレス</p>
                     <p class="w-full rounded border border-gray-300 p-2">
-                        email@example.com
+                        <%= @current_customer.customer_account.email%>
                     </p>
                 </div>
                 <div>
                     <p>電話番号</p>
                     <p class="w-full rounded border border-gray-300 p-2">
-                        123-4567-8901
+                        <%= @current_customer.customer_account.phone_number.blank? ? '---': @current_customer.customer_account.phone_number %>
                     </p>
                 </div>
                 <h2 class="text-xl font-bold md:text-2xl">2. お届け先</h2>
-                <p for="zip-code-front">郵便番号</p>
-                <div class="flex">
-                    <p class="w-1/3 rounded border border-gray-300 p-2">123</p>
-                    <p class="px-3 py-2">ー</p>
-                    <p class="w-1/3 rounded border border-gray-300 p-2">4567</p>
+                <div>
+                    <p >郵便番号</p>
+                    <p class="w-full rounded border border-gray-300 p-2"><%= @current_customer.address.zip_code.blank? ? '---': @current_customer.address.zip_code%></p>
                 </div>
                 <div>
-                    <p class="ml-1 block text-lg text-gray-900">都道府県</p>
-                    <p class="w-1/3 rounded border border-gray-300 p-2">北海道</p>
+                    <p class="block text-lg text-gray-900">都道府県</p>
+                    <p class="w-full rounded border border-gray-300 p-2"><%= @current_customer.address.prefecture.blank? ? '---': @current_customer.address.prefecture.name%></p>
+                </div>
+                <div>
+                    <p>市区町村</p>
+                    <p class="w-full rounded border border-gray-300 p-2">
+                        ---
+                    </p>
                 </div>
                 <div>
                     <p>住所(1行目)</p>
                     <p class="w-full rounded border border-gray-300 p-2">
-                        xx市oo町12-3
+                        <%= @current_customer.address.street_address.blank? ? '---': @current_customer.address.street_address%>
                     </p>
                 </div>
                 <div>
                     <p>住所(2行目)</p>
                     <p class="w-full rounded border border-gray-300 p-2">
-                        xxマンション123
+                        <%= @current_customer.address.street_address_2.blank? ? '---': @current_customer.address.street_address_2%>
                     </p>
                 </div>
                 <h2 class="text-xl font-bold md:text-2xl">3. お支払い方法</h2>

--- a/src/app/views/layouts/customer/_navbar.html.erb
+++ b/src/app/views/layouts/customer/_navbar.html.erb
@@ -83,7 +83,7 @@
               <%= link_to 'ダウンロードリスト', download_products_path, data: { turbo_method: :get }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
               </li>
               <li>
-                <a href="#" class="block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white">アカウント情報</a>
+                <%= link_to 'アカウント情報', account_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
               </li>
               <li>
                 <%= link_to 'ログアウト', destroy_customer_account_session_path, data: { turbo_method: :delete }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>

--- a/src/app/views/shared/_error_messages.html.erb
+++ b/src/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if model.errors.any? %>
-    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+    <div class="relative rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700" role="alert">
         <strong class="font-bold">通知:</strong>
         <ul class="list-disc pl-5">
             <% model.errors.each do |error| %>

--- a/src/app/views/shared/_error_messages.html.erb
+++ b/src/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,10 @@
+<% if model.errors.any? %>
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+        <strong class="font-bold">通知:</strong>
+        <ul class="list-disc pl-5">
+            <% model.errors.each do |error| %>
+                <li><%= error.full_message %></li>
+            <% end %>
+        </ul>
+    </div>
+<% end %>

--- a/src/config/locales/model.ja.yml
+++ b/src/config/locales/model.ja.yml
@@ -15,6 +15,7 @@ ja:
         password: "パスワード"
         password_confirmation: "パスワード（確認）"
         user_name: "ユーザー名"
+        phone_number: "電話番号"
       product:
         name: "名前"
         description: "説明"
@@ -24,3 +25,7 @@ ja:
         title: "タイトル"
         review: "レビュー"
         rating: "評価"
+      address:
+        zip_code: "郵便番号"
+        street_address: "住所(1行目)"
+        street_address_2: "住所(2行目)"

--- a/src/config/locales/model.ja.yml
+++ b/src/config/locales/model.ja.yml
@@ -16,6 +16,7 @@ ja:
         password_confirmation: "パスワード（確認）"
         user_name: "ユーザー名"
         phone_number: "電話番号"
+        shipping_name: "氏名"
       product:
         name: "名前"
         description: "説明"

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
     get 'checkout/success', to: 'checkouts#success'
 
     resources :orders, only: [:index]
+    resource :account, only: %i[show edit update]
   end
 
   namespace :webhooks do

--- a/src/db/migrate/20240603074543_add_shipping_name_to_customer_accounts.rb
+++ b/src/db/migrate/20240603074543_add_shipping_name_to_customer_accounts.rb
@@ -1,0 +1,5 @@
+class AddShippingNameToCustomerAccounts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :customer_accounts, :shipping_name, :string
+  end
+end

--- a/src/db/migrate/20240603075400_add_phone_number_to_customer_accounts.rb
+++ b/src/db/migrate/20240603075400_add_phone_number_to_customer_accounts.rb
@@ -1,0 +1,5 @@
+class AddPhoneNumberToCustomerAccounts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :customer_accounts, :phone_number, :string
+  end
+end

--- a/src/db/migrate/20240603081220_modify_addresses.rb
+++ b/src/db/migrate/20240603081220_modify_addresses.rb
@@ -1,0 +1,7 @@
+class ModifyAddresses < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :addresses, :state, :string
+    remove_column :addresses, :city, :string
+    add_column :addresses, :prefecture_id, :integer
+  end
+end

--- a/src/db/migrate/20240604084709_change_zip_code_type_in_addresses_table.rb
+++ b/src/db/migrate/20240604084709_change_zip_code_type_in_addresses_table.rb
@@ -1,0 +1,5 @@
+class ChangeZipCodeTypeInAddressesTable < ActiveRecord::Migration[7.1]
+  def change
+    change_column :addresses, :zip_code, :string
+  end
+end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_02_005424) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_03_081220) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -41,18 +41,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_02_005424) do
 
   create_table "addresses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "zip_code"
-    t.string "state"
-    t.string "city"
     t.string "street_address"
     t.string "street_address_2"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "addressable_type"
     t.bigint "addressable_id"
+    t.integer "prefecture_id"
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable"
-    t.index ["city", "zip_code"], name: "index_addresses_on_city_and_zip_code"
-    t.index ["city"], name: "index_addresses_on_city"
-    t.index ["state"], name: "index_addresses_on_state"
+    t.index ["zip_code"], name: "index_addresses_on_city_and_zip_code"
     t.index ["zip_code"], name: "index_addresses_on_zip_code"
   end
 
@@ -90,6 +87,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_02_005424) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "customer_id"
+    t.string "shipping_name"
+    t.string "phone_number"
     t.index ["confirmation_token"], name: "index_customer_accounts_on_confirmation_token", unique: true
     t.index ["customer_id"], name: "index_customer_accounts_on_customer_id"
     t.index ["email"], name: "index_customer_accounts_on_email", unique: true

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_03_081220) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_04_084709) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -40,7 +40,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_03_081220) do
   end
 
   create_table "addresses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "zip_code"
+    t.string "zip_code"
     t.string "street_address"
     t.string "street_address_2"
     t.datetime "created_at", null: false

--- a/src/spec/factories/addresses.rb
+++ b/src/spec/factories/addresses.rb
@@ -1,10 +1,5 @@
 FactoryBot.define do
   factory :address do
-    zip_code { '1234567' }
-    state { 'Tokyo' }
-    city { 'Chiyoda' }
-    street_address { '1-1-1' }
-    street_address_2 { 'Building 101' }
     addressable { association :customer }
   end
 end

--- a/src/spec/factories/customers.rb
+++ b/src/spec/factories/customers.rb
@@ -1,13 +1,5 @@
 FactoryBot.define do
   factory :customer do
-    after(:build) do |customer|
-      customer.build_address(
-        zip_code: '1234567',
-        state: 'Tokyo',
-        city: 'Chiyoda',
-        street_address: '1-1-1',
-        street_address_2: 'Building 101'
-      )
-    end
+    stripe_customer_id { 'sample_stripe_customer_id' }
   end
 end

--- a/src/spec/models/address_spec.rb
+++ b/src/spec/models/address_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  let(:customer) { create(:customer) }
+
+  it 'is valid with a addressable' do
+    address = described_class.new(addressable: customer)
+    expect(address).to be_valid
+  end
+
+  it 'allows NNN-NNNN format, blank, or nil for a zip code' do
+    address = build(:address)
+    expect(address).to be_valid
+
+    address.zip_code = nil
+    expect(address).to be_valid
+
+    address.zip_code = ''
+    expect(address).to be_valid
+  end
+
+  it 'does not allow formats other than NNN-NNNN for a zip code' do
+    address = build(:address)
+
+    # ハイフンなし
+    address.zip_code = '1234567'
+    address.valid?
+    expect(address.errors[:zip_code]).to include('の形式が不正です（例:123-4567）')
+
+    # 桁数がおかしい
+    address.zip_code = '1234-567'
+    expect(address.errors[:zip_code]).to include('の形式が不正です（例:123-4567）')
+
+    # 数字以外が入っている
+    address.zip_code = 'A12-567'
+    expect(address.errors[:zip_code]).to include('の形式が不正です（例:123-4567）')
+  end
+
+  it 'allows values from 1 to 47, blank or nil for a prefecture_id' do
+    address = build(:address)
+    expect(address).to be_valid
+
+    address.prefecture_id = ''
+    expect(address).to be_valid
+
+    address.prefecture_id = nil
+    expect(address).to be_valid
+  end
+
+  it 'does not allow other than 1 to 47 for a prefecture_id' do
+    address = build(:address)
+
+    address.prefecture_id = 0
+    address.valid?
+    expect(address.errors[:prefecture_id]).to include('は1..47の範囲に含めてください')
+
+    address.prefecture_id = 48
+    expect(address.errors[:prefecture_id]).to include('は1..47の範囲に含めてください')
+  end
+
+  it 'allows a maximum length of 200, blank, or nil for a street address' do
+    address = build(:address)
+
+    address.street_address = 'a' * 200
+    expect(address).to be_valid
+
+    address.street_address = 'a' * 199
+    expect(address).to be_valid
+
+    address.street_address = ''
+    expect(address).to be_valid
+
+    address.street_address = nil
+    expect(address).to be_valid
+  end
+
+  it 'does not allow more than 200 characters for a street address' do
+    address = build(:address)
+    address.street_address = 'a' * 201
+    address.valid?
+    expect(address.errors[:street_address]).to include('は200文字以内で入力してください')
+  end
+
+  it 'allows a maximum length of 200, blank, or nil for a street address_2' do
+    address = build(:address)
+
+    address.street_address_2 = 'a' * 200
+    expect(address).to be_valid
+
+    address.street_address_2 = 'a' * 199
+    expect(address).to be_valid
+
+    address.street_address_2 = ''
+    expect(address).to be_valid
+
+    address.street_address_2 = nil
+    expect(address).to be_valid
+  end
+
+  it 'does not allow more than 200 characters for a street address 2' do
+    address = build(:address)
+    address.street_address_2 = 'a' * 201
+    address.valid?
+    expect(address.errors[:street_address_2]).to include('は200文字以内で入力してください')
+  end
+end


### PR DESCRIPTION
## 概要
- ログインユーザーがアカウント情報を編集できる機能の実装
- 住所を入力した場合、決済時に自動入力される機能の実装

### Issue
https://github.com/recursion-backend-projects/E-Commerce-Webapp-with-Stripe-Sync/issues/42

## 目的
ログインユーザーが住所の入力の手間を省けるようにするため

## やったこと
- customer/accounts controller の作成
- prefectureクラスの作成
- show, editのビューの作成
- show, edit, updateアクションの作成
- バリデーションの作成
- 単体テストの作成
- 決済時に住所を自動入力させる振る舞いの実装
- [ER図](https://github.com/recursion-backend-projects/dev-log/blob/main/er.md)の修正

## やっていないこと
- Eメールの変更の振る舞い（再認証を求めるなど）

## 確認方法

1. ログインする
2. http://localhost:3000/account にアクセス
3. 「編集する」ボタンを押す
4. アカウント情報を入力する
5. 「保存する」ボタンを押す
6. なにか商品をカートに入れて決済画面に行く
7. アカウント情報が自動入力されているか確認する

## レビューで見てほしいこと、不安に思っていること
- アカウント情報の編集、保存、表示ができるか
- 入力した情報が決済時に自動入力されるか

## その他
- [ER図](https://github.com/recursion-backend-projects/dev-log/blob/main/er.md)のaccount tableとcustomer_accountテーブルを修正してます