### PR TITLE
ネットワーク設定

### DIFF
--- a/src/compose.yml
+++ b/src/compose.yml
@@ -15,6 +15,8 @@ services:
       retries: 10
     volumes:
       - ./db/mysql_data:/var/lib/mysql
+    networks:
+      - artsa2-network
 
   app:
     build:
@@ -33,6 +35,8 @@ services:
     tty: true
     stdin_open: true
     command: /bin/bash -c "rm -f tmp/pids/server.pid && yarn install && bin/dev"
+    networks:
+      - artsa2-network
 
   web:
     build: ../infra/dev/web
@@ -43,6 +47,8 @@ services:
     volumes:
       - ../infra/dev/web/default.conf:/etc/nginx/conf.d/default.conf
       - ./public:/E-Commerce-Webapp-with-Stripe-Sync/public
+    networks:
+      - artsa2-network
 
   stripe:
     image: stripe/stripe-cli:v1.19.5
@@ -63,6 +69,12 @@ services:
     environment:
       MH_STORAGE: maildir
       MH_MAILDIR_PATH: /tmp
+    networks:
+      - artsa2-network
 
 volumes:
   db-data:
+
+networks:
+  artsa2-network:
+    external: true


### PR DESCRIPTION
## 目的
Goコンテナとネットワークを共有する

こちらのPRで使います。
https://github.com/recursion-backend-projects/E-Commerce-Chat-Microservice/pull/2

### Issue
#71 

## やったこと
- Goコンテナとネットワークを共有する

## やってないこと
- stripeコンテナのみnetwork_mode: "service:app"の定義を外せないのでnetworkは設定してませんが問題なく動くと思います。


## レビューで見てほしいこと、不安に思っていること
- 既存のRails環境に不具合が出てないか

## その他
ネットワークの作成とビルドをお忘れなく。詳細はチャットの方のPRで確認お願いします。
何か質問あればどうぞ
