### PR TITLE
Feature/#91 chat list

### DIFF
--- a/infra/prod/web/default.conf
+++ b/infra/prod/web/default.conf
@@ -25,4 +25,16 @@ server {
     proxy_set_header Host $http_host;
     proxy_pass http://myapp;
   }
+
+   # WebSocketの設定
+  location /cable {
+    proxy_pass http://websocket;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
 }

--- a/infra/prod/web/default.conf
+++ b/infra/prod/web/default.conf
@@ -26,9 +26,9 @@ server {
     proxy_pass http://myapp;
   }
 
-   # WebSocketの設定
+  # WebSocketの設定
   location /cable {
-    proxy_pass http://websocket;
+    proxy_pass http://myapp;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";

--- a/infra/stg/web/default.conf
+++ b/infra/stg/web/default.conf
@@ -5,9 +5,20 @@ upstream myapp {
   server unix:///E-Commerce-Webapp-with-Stripe-Sync/tmp/sockets/puma.sock;
 }
 
+# HTTPからHTTPSへのリダイレクト設定
 server {
   listen 80;
   server_name art-sa2-stg.com;
+  return 301 https://$host$request_uri;
+}
+
+# HTTPSの設定
+server {
+  listen 443 ssl;
+  server_name art-sa2-stg.com;
+
+  ssl_certificate /etc/nginx/ssl/cert.pem; # HTTPS-PORTALが生成する証明書
+  ssl_certificate_key /etc/nginx/ssl/key.pem; # HTTPS-PORTALが生成するキー
 
   # ドキュメントルートの指定
   root /E-Commerce-Webapp-with-Stripe-Sync/public;

--- a/infra/stg/web/default.conf
+++ b/infra/stg/web/default.conf
@@ -25,4 +25,16 @@ server {
     proxy_set_header Host $http_host;
     proxy_pass http://myapp;
   }
+
+   # WebSocketの設定
+  location /cable {
+    proxy_pass http://websocket;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
 }

--- a/infra/stg/web/default.conf
+++ b/infra/stg/web/default.conf
@@ -5,20 +5,9 @@ upstream myapp {
   server unix:///E-Commerce-Webapp-with-Stripe-Sync/tmp/sockets/puma.sock;
 }
 
-# HTTPからHTTPSへのリダイレクト設定
 server {
   listen 80;
   server_name art-sa2-stg.com;
-  return 301 https://$host$request_uri;
-}
-
-# HTTPSの設定
-server {
-  listen 443 ssl;
-  server_name art-sa2-stg.com;
-
-  ssl_certificate /etc/nginx/ssl/cert.pem; # HTTPS-PORTALが生成する証明書
-  ssl_certificate_key /etc/nginx/ssl/key.pem; # HTTPS-PORTALが生成するキー
 
   # ドキュメントルートの指定
   root /E-Commerce-Webapp-with-Stripe-Sync/public;

--- a/infra/stg/web/default.conf
+++ b/infra/stg/web/default.conf
@@ -26,9 +26,9 @@ server {
     proxy_pass http://myapp;
   }
 
-   # WebSocketの設定
+  # WebSocketの設定
   location /cable {
-    proxy_pass http://websocket;
+    proxy_pass http://myapp;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -27,7 +27,7 @@ gem 'stimulus-rails'
 gem 'jbuilder'
 
 # Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
+gem "redis", ">= 4.0.1"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -27,7 +27,7 @@ gem 'stimulus-rails'
 gem 'jbuilder'
 
 # Use Redis adapter to run Action Cable in production
-gem "redis", ">= 4.0.1"
+gem 'redis', '>= 4.0.1'
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -282,6 +282,10 @@ GEM
       i18n
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
+    redis (5.2.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.2)
+      connection_pool
     regexp_parser (2.9.0)
     reline (0.5.0)
       io-console (~> 0.5)
@@ -415,6 +419,7 @@ DEPENDENCIES
   rails (~> 7.1.3, >= 7.1.3.2)
   rails-i18n
   ransack
+  redis (>= 4.0.1)
   rspec-rails (~> 6.1, >= 6.1.2)
   rubocop (~> 1.63, >= 1.63.3)
   rubocop-capybara (~> 2.20)

--- a/src/app/channels/chat_channel.rb
+++ b/src/app/channels/chat_channel.rb
@@ -1,0 +1,9 @@
+class ChatChannel < ApplicationCable::Channel
+  def subscribed
+    # stream_from "some_channel"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/src/app/channels/chat_channel.rb
+++ b/src/app/channels/chat_channel.rb
@@ -1,6 +1,6 @@
 class ChatChannel < ApplicationCable::Channel
   def subscribed
-    stream_from "chat_channel"
+    stream_from 'chat_channel'
   end
 
   def unsubscribed

--- a/src/app/channels/chat_channel.rb
+++ b/src/app/channels/chat_channel.rb
@@ -1,6 +1,6 @@
 class ChatChannel < ApplicationCable::Channel
   def subscribed
-    # stream_from "some_channel"
+    stream_from "chat_channel"
   end
 
   def unsubscribed

--- a/src/app/controllers/admin/chats_controller.rb
+++ b/src/app/controllers/admin/chats_controller.rb
@@ -34,6 +34,7 @@ class Admin::ChatsController < ApplicationController
   def update_status
     @chat = Chat.find(params[:id])
     if @chat.update(status: params[:status])
+      ActionCable.server.broadcast 'chat_channel', { action: 'update_status', chat: @chat }
       render json: { status: 'ok' }
     else
       render json: { status: 'error', message: @chat.errors.full_messages }, status: :unprocessable_entity

--- a/src/app/controllers/admin/chats_controller.rb
+++ b/src/app/controllers/admin/chats_controller.rb
@@ -31,6 +31,15 @@ class Admin::ChatsController < ApplicationController
     render json: { token: cookies.signed[:admin_jwt] }
   end
 
+  def update_status
+    @chat = Chat.find(params[:id])
+    if @chat.update(status: params[:status])
+      render json: { status: 'ok' }
+    else
+      render json: { status: 'error', message: @chat.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def admin_has_valid_token?

--- a/src/app/controllers/admin/chats_controller.rb
+++ b/src/app/controllers/admin/chats_controller.rb
@@ -10,6 +10,7 @@ class Admin::ChatsController < ApplicationController
   def show
     @admin = true
     @chat = Chat.find(params[:id])
+    @customer_account = @chat.customer.customer_account
     @websocket_url = Rails.env.production? ? ENV.fetch('WEBSOCKET_URL', nil) : 'ws://localhost:8080/chat'
 
     # 有効なトークンを既に持っているか確認

--- a/src/app/controllers/customer/chats_controller.rb
+++ b/src/app/controllers/customer/chats_controller.rb
@@ -12,6 +12,7 @@ class Customer::ChatsController < ApplicationController
 
     if @current_customer && customer_has_valid_token?
       @current_customer.chat.update(status: :waiting_for_admin)
+      ActionCable.server.broadcast 'chat_channel', { action: 'create', chat: @chat, customer_account: @current_customer.customer_account }
     else
       # 有効なトークンを持っていない場合は再作成
       token = @current_customer.generate_jwt

--- a/src/app/controllers/customer/chats_controller.rb
+++ b/src/app/controllers/customer/chats_controller.rb
@@ -7,7 +7,7 @@ class Customer::ChatsController < ApplicationController
     if @current_customer.chat.blank?
       chat = @current_customer.create_chat(status: :waiting_for_admin)
       ActionCable.server.broadcast 'chat_channel', { action: 'create', chat: chat }
-    else
+    end
 
     if @current_customer && customer_has_valid_token?
       @current_customer.chat.update(status: :waiting_for_admin)

--- a/src/app/controllers/customer/chats_controller.rb
+++ b/src/app/controllers/customer/chats_controller.rb
@@ -6,7 +6,7 @@ class Customer::ChatsController < ApplicationController
 
     if @current_customer.chat.blank?
       chat = @current_customer.create_chat(status: :waiting_for_admin)
-      ActionCable.server.broadcast 'chat_channel', { action: 'create', chat: chat, customer_account: @current_customer.customer_account }
+      ActionCable.server.broadcast 'chat_channel', { action: 'create', chat:, customer_account: @current_customer.customer_account }
     end
 
     if @current_customer && customer_has_valid_token?

--- a/src/app/controllers/customer/chats_controller.rb
+++ b/src/app/controllers/customer/chats_controller.rb
@@ -4,7 +4,10 @@ class Customer::ChatsController < ApplicationController
     @customer = true
     @websocket_url = Rails.env.production? ? ENV.fetch('WEBSOCKET_URL', nil) : 'ws://localhost:8080/chat'
 
-    @current_customer.create_chat(status: :waiting_for_admin) if @current_customer.chat.blank?
+    if @current_customer.chat.blank?
+      chat = @current_customer.create_chat(status: :waiting_for_admin)
+      ActionCable.server.broadcast 'chat_channel', { action: 'create', chat: chat }
+    else
 
     if @current_customer && customer_has_valid_token?
       @current_customer.chat.update(status: :waiting_for_admin)

--- a/src/app/controllers/customer/chats_controller.rb
+++ b/src/app/controllers/customer/chats_controller.rb
@@ -6,7 +6,7 @@ class Customer::ChatsController < ApplicationController
 
     if @current_customer.chat.blank?
       chat = @current_customer.create_chat(status: :waiting_for_admin)
-      ActionCable.server.broadcast 'chat_channel', { action: 'create', chat: chat }
+      ActionCable.server.broadcast 'chat_channel', { action: 'create', chat: chat, customer_account: @current_customer.customer_account }
     end
 
     if @current_customer && customer_has_valid_token?

--- a/src/app/javascript/admin_chat.ts
+++ b/src/app/javascript/admin_chat.ts
@@ -77,6 +77,11 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   document.getElementById("disconnect")!.addEventListener("click", async function (e) {
     e.preventDefault();
+    const confirmDisconnect = confirm("本当に接続を解除しますか？");
+    if (!confirmDisconnect) {
+      return;
+    }
+
     const chatIdElement = document.getElementById("chat-id");
     const chatId = chatIdElement?.getAttribute("data-chat-id");
     if (chatId) {

--- a/src/app/javascript/admin_chat.ts
+++ b/src/app/javascript/admin_chat.ts
@@ -119,7 +119,10 @@ document.addEventListener("DOMContentLoaded", async function () {
   chatInput?.addEventListener("keydown", handleEnterKey);
 
   function sendMessage() {
-    const message = chatInput?.value;
+    const message = chatInput?.value.trim();
+    if (!message) {
+      return;
+    }
     socket.send(message);
     console.log(`me: ${message}`);
     displayMessage(message, "sent");

--- a/src/app/javascript/admin_chat.ts
+++ b/src/app/javascript/admin_chat.ts
@@ -61,6 +61,15 @@ document.addEventListener("DOMContentLoaded", async function () {
     displayMessage(event.data, "received");
   };
 
+  window.addEventListener("beforeunload", async function (event) {
+    const chatIdElement = document.getElementById("chat-id");
+    const chatId = chatIdElement?.getAttribute("data-chat-id");
+    if (chatId) {
+      await updateChatStatus(chatId, 'offline');
+    }
+    socket.close();
+  });
+
   document.getElementById("submit")!.addEventListener("click", function (e) {
     e.preventDefault();
     sendMessage();

--- a/src/app/javascript/admin_chat.ts
+++ b/src/app/javascript/admin_chat.ts
@@ -46,7 +46,8 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
 
     // 初回メッセージを送信
-    const initialMessage = `お客様への対応をスムーズに進めるために、以下の情報をお教えいただけますか？<br /><br />
+    const initialMessage = `お待たせ致しました。<br />これよりサポートを開始いたします。
+    お客様への対応をスムーズに進めるために、以下の情報をお教えいただけますか？<br /><br />
     1. ご注文番号<br />
     2. ご注文日時<br />
     3. 商品名<br />

--- a/src/app/javascript/admin_chat.ts
+++ b/src/app/javascript/admin_chat.ts
@@ -65,6 +65,17 @@ document.addEventListener("DOMContentLoaded", async function () {
     sendMessage();
   });
 
+  document.getElementById("disconnect")!.addEventListener("click", async function (e) {
+    e.preventDefault();
+    const chatIdElement = document.getElementById("chat-id");
+    const chatId = chatIdElement?.getAttribute("data-chat-id");
+    if (chatId) {
+      await updateChatStatus(chatId, 'offline');
+    }
+    socket.close();
+    alert('接続を解除しました。');
+  });
+
   const chatInput = document.getElementById("chat") as HTMLInputElement;
   chatInput?.focus();
 

--- a/src/app/javascript/admin_chat.ts
+++ b/src/app/javascript/admin_chat.ts
@@ -5,6 +5,25 @@ document.addEventListener("DOMContentLoaded", async function () {
     return data.token;
   }
 
+  async function updateChatStatus(chatId: string, status: string) {
+    let response = await fetch(`/admin/chats/${chatId}/update_status`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || ''
+      },
+      body: JSON.stringify({ status: status })
+    });
+
+    let data = await response.json();
+    if (data.status === 'ok') {
+      console.log('Chat status updated successfully');
+    } else {
+      alert('予期せぬエラーが発生しました。再接続をしてください。');
+      return;
+    }
+  }
+
   let token = await getToken();
 
   const websocketUrl = document
@@ -13,8 +32,14 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   const socket = new WebSocket(`${websocketUrl}?token=${token}`);
 
-  socket.onopen = function (event) {
+  socket.onopen =  async function (event) {
     console.log("Connected to WebSocket server.");
+
+    const chatIdElement = document.getElementById("chat-id");
+    const chatId = chatIdElement?.getAttribute("data-chat-id");
+    if (chatId) {
+      await updateChatStatus(chatId, 'chatting');
+    }
 
     // 初回メッセージを送信
     const initialMessage = `お客様への対応をスムーズに進めるために、以下の情報をお教えいただけますか？<br /><br />

--- a/src/app/javascript/admin_chat.ts
+++ b/src/app/javascript/admin_chat.ts
@@ -53,6 +53,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   socket.onclose = function (event) {
     console.log("Disconnected from WebSocket server.");
+    alert("通信が切断されました。")
   };
 
   socket.onmessage = function (event) {
@@ -73,7 +74,6 @@ document.addEventListener("DOMContentLoaded", async function () {
       await updateChatStatus(chatId, 'offline');
     }
     socket.close();
-    alert('接続を解除しました。');
   });
 
   const chatInput = document.getElementById("chat") as HTMLInputElement;

--- a/src/app/javascript/application.js
+++ b/src/app/javascript/application.js
@@ -1,4 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "./controllers"
-import "flowbite/dist/flowbite.turbo.js"import "./channels"
+import "flowbite/dist/flowbite.turbo.js"
+import "./channels"

--- a/src/app/javascript/application.js
+++ b/src/app/javascript/application.js
@@ -1,4 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "./controllers"
-import "flowbite/dist/flowbite.turbo.js"
+import "flowbite/dist/flowbite.turbo.js"import "./channels"

--- a/src/app/javascript/channels/chat_channel.js
+++ b/src/app/javascript/channels/chat_channel.js
@@ -1,0 +1,15 @@
+import consumer from "./consumer"
+
+consumer.subscriptions.create("ChatChannel", {
+  connected() {
+    // Called when the subscription is ready for use on the server
+  },
+
+  disconnected() {
+    // Called when the subscription has been terminated by the server
+  },
+
+  received(data) {
+    // Called when there's incoming data on the websocket for this channel
+  }
+});

--- a/src/app/javascript/channels/chat_channel.js
+++ b/src/app/javascript/channels/chat_channel.js
@@ -20,7 +20,6 @@ consumer.subscriptions.create("ChatChannel", {
   }
 });
 
-
 function addChat(chat, customerAccount) {
   const chatList = document.querySelector('tbody');
   const chatRow = document.createElement('tr');
@@ -37,15 +36,17 @@ function addChat(chat, customerAccount) {
             未対応
           </div>
         ` : `
-          <div class="flex items"center dark:text-white">
+          <div class="flex items-center dark:text-white">
             <div class="me-2 h-2.5 w-2.5 rounded-full bg-green-500"></div>
             対応中
           </div>
         `}
       </div>
     </td>
-    <td class="space-x-2 px-2 py-4 md:space-x-10 md:px-6">
-      <a href="/admin/chats/${chat.id}" data-turbo="false" class="font-medium text-sky-600 hover:underline">接続する</a>
+    <td id="action-cell" class="space-x-2 px-2 py-4 md:space-x-10 md:px-6">
+      ${chat.status !== 'chatting' ? `
+        <a href="/admin/chats/${chat.id}" data-turbo="false" class="font-medium text-sky-600 hover:underline">接続する</a>
+      ` : ''}
     </td>
   `;
   chatList.appendChild(chatRow);
@@ -75,13 +76,13 @@ function updateChatStatus(chat) {
           </div>
         `;
       }
-    }
 
-    const actionCell = chatRow.querySelector('#action-cell');
+      const actionCell = chatRow.querySelector('#action-cell');
       if (actionCell) {
         actionCell.innerHTML = chat.status !== 'chatting' ? `
           <a href="/admin/chats/${chat.id}" data-turbo="false" class="font-medium text-sky-600 hover:underline">接続する</a>
         ` : '';
       }
+    }
   }
 }

--- a/src/app/javascript/channels/chat_channel.js
+++ b/src/app/javascript/channels/chat_channel.js
@@ -76,5 +76,12 @@ function updateChatStatus(chat) {
         `;
       }
     }
+
+    const actionCell = chatRow.querySelector('#action-cell');
+      if (actionCell) {
+        actionCell.innerHTML = chat.status !== 'chatting' ? `
+          <a href="/admin/chats/${chat.id}" data-turbo="false" class="font-medium text-sky-600 hover:underline">接続する</a>
+        ` : '';
+      }
   }
 }

--- a/src/app/javascript/channels/chat_channel.js
+++ b/src/app/javascript/channels/chat_channel.js
@@ -22,6 +22,12 @@ consumer.subscriptions.create("ChatChannel", {
 
 function addChat(chat, customerAccount) {
   const chatList = document.querySelector('tbody');
+
+  // 既に該当チャットが存在する場合は追加しない
+  if (document.getElementById(`chat-${chat.id}`)) {
+    return;
+  }
+
   const chatRow = document.createElement('tr');
   chatRow.className = 'bg-gre border-b bg-white hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:border-gray-700 dark:bg-gray-800';
   chatRow.id = `chat-${chat.id}`;

--- a/src/app/javascript/channels/chat_channel.js
+++ b/src/app/javascript/channels/chat_channel.js
@@ -11,7 +11,6 @@ consumer.subscriptions.create("ChatChannel", {
 
   received(data) {
     // ブロードキャストされたデータをキャッチ
-    console.log(data.chat)
     if (data.action === 'create') {
       addChat(data.chat, data.customer_account);
     } else if (data.action === 'update_status') {

--- a/src/app/javascript/channels/chat_channel.js
+++ b/src/app/javascript/channels/chat_channel.js
@@ -14,6 +14,8 @@ consumer.subscriptions.create("ChatChannel", {
     console.log(data.chat)
     if (data.action === 'create') {
       addChat(data.chat, data.customer_account);
+    } else if (data.action === 'update_status') {
+      updateChatStatus(data.chat);
     }
   }
 });
@@ -27,7 +29,7 @@ function addChat(chat, customerAccount) {
   chatRow.innerHTML = `
     <td class="px-6 py-4 font-semibold dark:text-white">${customerAccount.email}</td>
     <td class="px-6 py-4 dark:text-white">${new Date(chat.created_at).toLocaleString()}</td>
-    <td class="px-6 py-4 dark:text-white">
+    <td id="status-cell" class="px-6 py-4 dark:text-white">
       <div class="flex items-center">
         ${chat.status === 'waiting_for_admin' ? `
           <div class="flex items-center dark:text-white">
@@ -47,4 +49,32 @@ function addChat(chat, customerAccount) {
     </td>
   `;
   chatList.appendChild(chatRow);
+}
+
+function updateChatStatus(chat) {
+  const chatRow = document.querySelector(`#chat-${chat.id}`);
+  if (chatRow) {
+    if (chat.status === 'offline') {
+      chatRow.remove();
+    } else {
+      const statusCell = chatRow.querySelector('#status-cell');
+      if (statusCell) {
+        statusCell.innerHTML = `
+          <div class="flex items-center">
+            ${chat.status === 'waiting_for_admin' ? `
+              <div class="flex items-center dark:text-white">
+                <div class="me-2 h-2.5 w-2.5 rounded-full bg-yellow-500"></div>
+                未対応
+              </div>
+            ` : `
+              <div class="flex items-center dark:text-white">
+                <div class="me-2 h-2.5 w-2.5 rounded-full bg-green-500"></div>
+                対応中
+              </div>
+            `}
+          </div>
+        `;
+      }
+    }
+  }
 }

--- a/src/app/javascript/channels/chat_channel.js
+++ b/src/app/javascript/channels/chat_channel.js
@@ -10,6 +10,41 @@ consumer.subscriptions.create("ChatChannel", {
   },
 
   received(data) {
-    // Called when there's incoming data on the websocket for this channel
+    // ブロードキャストされたデータをキャッチ
+    console.log(data.chat)
+    if (data.action === 'create') {
+      addChat(data.chat, data.customer_account);
+    }
   }
 });
+
+
+function addChat(chat, customerAccount) {
+  const chatList = document.querySelector('tbody');
+  const chatRow = document.createElement('tr');
+  chatRow.className = 'bg-gre border-b bg-white hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:border-gray-700 dark:bg-gray-800';
+  chatRow.id = `chat-${chat.id}`;
+  chatRow.innerHTML = `
+    <td class="px-6 py-4 font-semibold dark:text-white">${customerAccount.email}</td>
+    <td class="px-6 py-4 dark:text-white">${new Date(chat.created_at).toLocaleString()}</td>
+    <td class="px-6 py-4 dark:text-white">
+      <div class="flex items-center">
+        ${chat.status === 'waiting_for_admin' ? `
+          <div class="flex items-center dark:text-white">
+            <div class="me-2 h-2.5 w-2.5 rounded-full bg-yellow-500"></div>
+            未対応
+          </div>
+        ` : `
+          <div class="flex items"center dark:text-white">
+            <div class="me-2 h-2.5 w-2.5 rounded-full bg-green-500"></div>
+            対応中
+          </div>
+        `}
+      </div>
+    </td>
+    <td class="space-x-2 px-2 py-4 md:space-x-10 md:px-6">
+      <a href="/admin/chats/${chat.id}" data-turbo="false" class="font-medium text-sky-600 hover:underline">接続する</a>
+    </td>
+  `;
+  chatList.appendChild(chatRow);
+}

--- a/src/app/javascript/channels/consumer.js
+++ b/src/app/javascript/channels/consumer.js
@@ -1,0 +1,6 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the `bin/rails generate channel` command.
+
+import { createConsumer } from "@rails/actioncable"
+
+export default createConsumer()

--- a/src/app/javascript/channels/index.js
+++ b/src/app/javascript/channels/index.js
@@ -1,0 +1,2 @@
+// Import all the channels to be used by Action Cable
+import "./chat_channel"

--- a/src/app/javascript/customer_chat.ts
+++ b/src/app/javascript/customer_chat.ts
@@ -96,7 +96,10 @@ document.addEventListener("DOMContentLoaded", async function () {
   chatInput?.addEventListener("keydown", handleEnterKey);
 
   function sendMessage() {
-    const message = chatInput?.value;
+    const message = chatInput?.value.trim();
+    if (!message) {
+      return;
+    }
     socket.send(message);
     console.log(`me: ${message}`);
     displayMessage(message, "sent");

--- a/src/app/javascript/customer_chat.ts
+++ b/src/app/javascript/customer_chat.ts
@@ -47,6 +47,11 @@ document.addEventListener("DOMContentLoaded", async function () {
     displayMessage(event.data, "received");
   };
 
+  window.addEventListener("beforeunload", async function (event) {
+    await updateChatStatus('offline');
+    socket.close();
+  });
+
   document.getElementById("submit")!.addEventListener("click", function (e) {
     e.preventDefault();
     sendMessage();

--- a/src/app/javascript/customer_chat.ts
+++ b/src/app/javascript/customer_chat.ts
@@ -5,6 +5,26 @@ document.addEventListener("DOMContentLoaded", async function () {
     return data.token;
   }
 
+  async function updateChatStatus(status: string) {
+    let response = await fetch(`/chat/update_status`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || ''
+      },
+      body: JSON.stringify({ status: status })
+    });
+
+    let data = await response.json();
+    console.log(data);
+    if (data.status === 'ok') {
+      console.log('Chat status updated successfully');
+    } else {
+      alert('予期せぬエラーが発生しました。再接続をしてください。');
+      return;
+    }
+  }
+
   let token = await getToken();
 
   const websocketUrl = document
@@ -29,6 +49,13 @@ document.addEventListener("DOMContentLoaded", async function () {
   document.getElementById("submit")!.addEventListener("click", function (e) {
     e.preventDefault();
     sendMessage();
+  });
+
+  document.getElementById("disconnect")!.addEventListener("click", async function (e) {
+    e.preventDefault();
+    await updateChatStatus('offline');
+    socket.close();
+    alert('接続を解除しました。');
   });
 
   const chatInput = document.getElementById("chat") as HTMLInputElement;

--- a/src/app/javascript/customer_chat.ts
+++ b/src/app/javascript/customer_chat.ts
@@ -58,6 +58,11 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   document.getElementById("disconnect")!.addEventListener("click", async function (e) {
     e.preventDefault();
+    const confirmDisconnect = confirm("本当に接続を解除しますか？");
+    if (!confirmDisconnect) {
+      return;
+    }
+
     await updateChatStatus('offline');
     socket.close();
   });

--- a/src/app/javascript/customer_chat.ts
+++ b/src/app/javascript/customer_chat.ts
@@ -38,6 +38,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   socket.onopen = function (event) {
     console.log("Connected to WebSocket server.");
+    initNotification();
   };
 
   socket.onclose = function (event) {
@@ -91,6 +92,13 @@ document.addEventListener("DOMContentLoaded", async function () {
       e.preventDefault();
       sendMessage();
     }
+  }
+
+  function initNotification() {
+    const notificationMessage = `カスタマーサポートの担当者が対応します。しばらくお待ちください。<br>
+      ※カスタマーサポートから次のメッセージが表示されるまでは、メッセージを送信してもカスタマーサポートには、表示されませんのでご注意ください。
+    `;
+    displayMessage(notificationMessage, "received");
   }
 
   chatInput?.addEventListener("keydown", handleEnterKey);

--- a/src/app/javascript/customer_chat.ts
+++ b/src/app/javascript/customer_chat.ts
@@ -16,7 +16,6 @@ document.addEventListener("DOMContentLoaded", async function () {
     });
 
     let data = await response.json();
-    console.log(data);
     if (data.status === 'ok') {
       console.log('Chat status updated successfully');
     } else {

--- a/src/app/javascript/customer_chat.ts
+++ b/src/app/javascript/customer_chat.ts
@@ -39,6 +39,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   socket.onclose = function (event) {
     console.log("Disconnected from WebSocket server.");
+    alert("通信が切断されました。")
   };
 
   socket.onmessage = function (event) {
@@ -55,7 +56,6 @@ document.addEventListener("DOMContentLoaded", async function () {
     e.preventDefault();
     await updateChatStatus('offline');
     socket.close();
-    alert('接続を解除しました。');
   });
 
   const chatInput = document.getElementById("chat") as HTMLInputElement;

--- a/src/app/views/admin/chats/index.html.erb
+++ b/src/app/views/admin/chats/index.html.erb
@@ -15,10 +15,10 @@
                 </thead>
                 <tbody>
                     <% @chats.each do |chat|%>
-                        <tr class="bg-gre border-b bg-white hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:border-gray-700 dark:bg-gray-800">
+                        <tr id="chat-<%= chat.id %>" class="bg-gre border-b bg-white hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:border-gray-700 dark:bg-gray-800">
                             <td class="px-6 py-4 font-semibold dark:text-white"><%= chat.customer.customer_account.email %></td>
                             <td class="px-6 py-4 dark:text-white"><%= chat.created_at.strftime("%Y-%m-%d %H:%M") %></td>
-                            <td class="px-6 py-4 dark:text-white">
+                            <td id="status-cell" class="px-6 py-4 dark:text-white">
                                 <div class="flex items-center">
                                     <% if chat.status == "waiting_for_admin"%>
                                         <!-- 未対応 -->

--- a/src/app/views/admin/chats/index.html.erb
+++ b/src/app/views/admin/chats/index.html.erb
@@ -35,8 +35,10 @@
                                     <% end %>
                                 </div>
                             </td>
-                            <td class="space-x-2 px-2 py-4 md:space-x-10 md:px-6">
-								<%= link_to '接続する', admin_chat_path(chat),  data: { turbo: :false },  class: 'font-medium text-sky-600 hover:underline' %>
+                            <td id="action-cell" class="space-x-2 px-2 py-4 md:space-x-10 md:px-6">
+                                <% if chat.status == "waiting_for_admin"%>
+								    <%= link_to '接続する', admin_chat_path(chat),  data: { turbo: :false },  class: 'font-medium text-sky-600 hover:underline' %>
+                                <% end %>
                             </td>
                         </tr>
                     <% end %>

--- a/src/app/views/admin/chats/show.html.erb
+++ b/src/app/views/admin/chats/show.html.erb
@@ -5,7 +5,7 @@
 				チャット
 			</h1>
 			<!-- カスタマーアイコン -->
-			<div class="flex items-center justify-between w-full">
+			<div class="flex w-full items-center justify-between">
         <div class="flex items-center gap-4">
           <div
             class="relative size-8 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-600"

--- a/src/app/views/admin/chats/show.html.erb
+++ b/src/app/views/admin/chats/show.html.erb
@@ -24,7 +24,7 @@
             </svg>
           </div>
           <div class="font-medium">
-            <div>カスタマーサポート</div>
+            <div><%= @customer_account.email %></div>
           </div>
         </div>
         <button

--- a/src/app/views/admin/chats/show.html.erb
+++ b/src/app/views/admin/chats/show.html.erb
@@ -99,4 +99,5 @@
 	</div>
 </div>
 <div id="websocket-url" data-websocket-url="<%= @websocket_url %>"></div>
+<div id="chat-id" data-chat-id="<%= @chat.id %>"></div>
 <%= javascript_include_tag 'admin_chat.js', type: "module" %>

--- a/src/app/views/admin/chats/show.html.erb
+++ b/src/app/views/admin/chats/show.html.erb
@@ -5,27 +5,35 @@
 				チャット
 			</h1>
 			<!-- カスタマーアイコン -->
-			<div class="flex items-center gap-4">
-				<div
-					class="relative size-8 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-600"
-				>
-					<svg
-						class="absolute -left-1 size-12 text-gray-400"
-						fill="currentColor"
-						viewBox="0 0 24 24"
-						xmlns="http://www.w3.org/2000/svg"
-					>
-						<path
-							fill-rule="evenodd"
-							d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-							clip-rule="evenodd"
-						></path>
-					</svg>
-				</div>
-				<div class="font-medium">
-					<div>ユーザーID、名前、Eメールなど</div>
-				</div>
-			</div>
+			<div class="flex items-center justify-between w-full">
+        <div class="flex items-center gap-4">
+          <div
+            class="relative size-8 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-600"
+          >
+            <svg
+              class="absolute -left-1 size-12 text-gray-400"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+                clip-rule="evenodd"
+              ></path>
+            </svg>
+          </div>
+          <div class="font-medium">
+            <div>カスタマーサポート</div>
+          </div>
+        </div>
+        <button
+          id="disconnect"
+          class="inline-flex cursor-pointer justify-center rounded-lg bg-red-500 p-2 text-white hover:bg-red-700"
+        >
+          接続解除
+        </button>
+      </div>
 			<!-- チャット -->
 			<div
 				class="divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white px-3 py-2 shadow-xl"

--- a/src/app/views/customer/chats/show.html.erb
+++ b/src/app/views/customer/chats/show.html.erb
@@ -1,106 +1,114 @@
 <div class="mb-10 flex flex-col items-center py-10 antialiased">
-	<div class="flex w-full flex-col py-4 md:w-3/4 lg:w-1/2">
-		<div class="container items-center justify-center space-y-4 px-6 md:pl-0">
-			<h1 class="text-center text-2xl font-bold md:text-start md:text-4xl">
-				チャット
-			</h1>
-			<p class="text-base text-gray-500 md:text-lg">
-				カスタマーサポートの担当者がご質問に回答します。<br />
-				お気軽に相談ください。
-			</p>
-			<!-- カスタマーサポートアイコン -->
-			<div class="flex items-center gap-4">
-				<div
-					class="relative size-8 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-600"
-				>
-					<svg
-						class="absolute -left-1 size-12 text-gray-400"
-						fill="currentColor"
-						viewBox="0 0 24 24"
-						xmlns="http://www.w3.org/2000/svg"
-					>
-						<path
-							fill-rule="evenodd"
-							d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-							clip-rule="evenodd"
-						></path>
-					</svg>
-				</div>
-				<div class="font-medium">
-					<div>カスタマーサポート</div>
-				</div>
-			</div>
-			<!-- チャット -->
-			<div
-				class="divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white px-3 py-2 shadow-xl"
-			>
-				<div class="min-h-screen space-y-4 p-4" id="chat-container">
-				</div>
-				<!-- チャット 入力フォーム -->
-				<form>
-					<label for="chat" class="sr-only">メッセージ</label>
-					<div class="flex items-center px-3 py-2">
-						<button
-							type="button"
-							class="inline-flex cursor-pointer justify-center rounded-lg p-2 text-sky-400 hover:bg-sky-100"
-						>
-							<svg
-								class="size-5"
-								aria-hidden="true"
-								xmlns="http://www.w3.org/2000/svg"
-								fill="none"
-								viewBox="0 0 20 18"
-							>
-								<path
-									fill="currentColor"
-									d="M13 5.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0ZM7.565 7.423 4.5 14h11.518l-2.516-3.71L11 13 7.565 7.423Z"
-								/>
-								<path
-									stroke="currentColor"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M18 1H2a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1Z"
-								/>
-								<path
-									stroke="currentColor"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M13 5.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0ZM7.565 7.423 4.5 14h11.518l-2.516-3.71L11 13 7.565 7.423Z"
-								/>
-							</svg>
-							<span class="sr-only">画像のアップロード</span>
-						</button>
-						<textarea
-							id="chat"
-							rows="1"
-							class="mx-4 block w-full rounded-lg border border-gray-100 bg-gray-100 p-2.5 text-sm placeholder:text-gray-400 focus:border-blue-500 focus:ring-blue-500"
-							placeholder="メッセージを送信"
-						></textarea>
-						<button
-							id="submit"
-							type="submit"
-							class="inline-flex cursor-pointer justify-center rounded-full p-2 text-sky-400 hover:bg-sky-100"
-						>
-							<svg
-								class="size-5 rotate-90 rtl:-rotate-90"
-								aria-hidden="true"
-								xmlns="http://www.w3.org/2000/svg"
-								fill="currentColor"
-								viewBox="0 0 18 20"
-							>
-								<path
-									d="m17.914 18.594-8-18a1 1 0 0 0-1.828 0l-8 18a1 1 0 0 0 1.157 1.376L8 18.281V9a1 1 0 0 1 2 0v9.281l6.758 1.689a1 1 0 0 0 1.156-1.376Z"
-								/>
-							</svg>
-							<span class="sr-only">メッセージを送信</span>
-						</button>
-					</div>
-				</form>
-			</div>
-		</div>
-	</div>
+  <div class="flex w-full flex-col py-4 md:w-3/4 lg:w-1/2">
+    <div class="container items-center justify-center space-y-4 px-6 md:pl-0">
+      <h1 class="text-center text-2xl font-bold md:text-start md:text-4xl">
+        チャット
+      </h1>
+      <p class="text-base text-gray-500 md:text-lg">
+        カスタマーサポートの担当者がご質問に回答します。<br />
+        お気軽に相談ください。
+      </p>
+      <!-- カスタマーサポートアイコンと接続解除ボタン -->
+      <div class="flex items-center justify-between w-full">
+        <div class="flex items-center gap-4">
+          <div
+            class="relative size-8 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-600"
+          >
+            <svg
+              class="absolute -left-1 size-12 text-gray-400"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+                clip-rule="evenodd"
+              ></path>
+            </svg>
+          </div>
+          <div class="font-medium">
+            <div>カスタマーサポート</div>
+          </div>
+        </div>
+        <button
+          id="disconnect"
+          class="inline-flex cursor-pointer justify-center rounded-lg bg-red-500 p-2 text-white hover:bg-red-700"
+        >
+          接続解除
+        </button>
+      </div>
+      <!-- チャット -->
+      <div
+        class="divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white px-3 py-2 shadow-xl"
+      >
+        <div class="min-h-screen space-y-4 p-4" id="chat-container"></div>
+        <!-- チャット 入力フォーム -->
+        <form>
+          <label for="chat" class="sr-only">メッセージ</label>
+          <div class="flex items-center px-3 py-2">
+            <button
+              type="button"
+              class="inline-flex cursor-pointer justify-center rounded-lg p-2 text-sky-400 hover:bg-sky-100"
+            >
+              <svg
+                class="size-5"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 20 18"
+              >
+                <path
+                  fill="currentColor"
+                  d="M13 5.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0ZM7.565 7.423 4.5 14h11.518l-2.516-3.71L11 13 7.565 7.423Z"
+                />
+                <path
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M18 1H2a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1Z"
+                />
+                <path
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M13 5.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0ZM7.565 7.423 4.5 14h11.518l-2.516-3.71L11 13 7.565 7.423Z"
+                />
+              </svg>
+              <span class="sr-only">画像のアップロード</span>
+            </button>
+            <textarea
+              id="chat"
+              rows="1"
+              class="mx-4 block w-full rounded-lg border border-gray-100 bg-gray-100 p-2.5 text-sm placeholder:text-gray-400 focus:border-blue-500 focus:ring-blue-500"
+              placeholder="メッセージを送信"
+            ></textarea>
+            <button
+              id="submit"
+              type="submit"
+              class="inline-flex cursor-pointer justify-center rounded-full p-2 text-sky-400 hover:bg-sky-100"
+            >
+              <svg
+                class="size-5 rotate-90 rtl:-rotate-90"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="currentColor"
+                viewBox="0 0 18 20"
+              >
+                <path
+                  d="m17.914 18.594-8-18a1 1 0 0 0-1.828 0l-8 18a1 1 0 0 0 1.157 1.376L8 18.281V9a1 1 0 0 1 2 0v9.281l6.758 1.689a1 1 0 0 0 1.156-1.376Z"
+                />
+              </svg>
+              <span class="sr-only">メッセージを送信</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 </div>
 <div id="websocket-url" data-websocket-url="<%= @websocket_url %>"></div>
+<div id="chat-id" data-chat-id="<%= @chat.id %>"></div>
 <%= javascript_include_tag 'customer_chat.js', type: "module" %>

--- a/src/app/views/customer/chats/show.html.erb
+++ b/src/app/views/customer/chats/show.html.erb
@@ -9,7 +9,7 @@
         お気軽に相談ください。
       </p>
       <!-- カスタマーサポートアイコンと接続解除ボタン -->
-      <div class="flex items-center justify-between w-full">
+      <div class="flex w-full items-center justify-between">
         <div class="flex items-center gap-4">
           <div
             class="relative size-8 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-600"

--- a/src/app/views/layouts/admin/_navbar.html.erb
+++ b/src/app/views/layouts/admin/_navbar.html.erb
@@ -62,20 +62,20 @@
             aria-labelledby="menuDropdownButton"
           >
             <li>
-              <%= link_to '商品管理', admin_products_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+              <%= link_to '商品管理', admin_products_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
             </li>
             <li>
-              <%= link_to '発送管理', admin_shippings_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+              <%= link_to '発送管理', admin_shippings_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
             </li>
             <li>
-              <%= link_to 'タグ一覧', admin_products_tags_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+              <%= link_to 'タグ一覧', admin_products_tags_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
             </li>
             <li>
-              <%= link_to 'チャット一覧', admin_chats_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+              <%= link_to 'チャット一覧', admin_chats_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
             </li>
             <!-- ログインユーザーの場合 -->
             <li>
-            <%= link_to 'ログアウト', destroy_admin_account_session_path, data: { turbo_method: :delete }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+            <%= link_to 'ログアウト', destroy_admin_account_session_path, data: { turbo_method: :delete }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
             </li>
           </ul>
         </div>

--- a/src/app/views/layouts/customer/_navbar.html.erb
+++ b/src/app/views/layouts/customer/_navbar.html.erb
@@ -71,29 +71,29 @@
         <div id="menuDropdown" class="z-10 hidden w-44 divide-y divide-gray-100 rounded bg-white shadow dark:divide-gray-600 dark:bg-gray-700">
           <ul class="py-1 text-sm text-gray-800 dark:text-gray-200" aria-labelledby="menuDropdownButton">
             <li>
-              <%= link_to 'ホーム', root_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+              <%= link_to 'ホーム', root_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
             </li>
             <% if current_customer_account %>
               <li>
-                <%= link_to 'ウィッシュリスト', customer_account_wish_products_path(current_customer_account), data: { turbo_method: :get }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+                <%= link_to 'ウィッシュリスト', customer_account_wish_products_path(current_customer_account), data: { turbo_method: :get }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
               </li>
               <li>
-                <%= link_to 'お気に入り', favorite_products_path, data: { turbo_method: :get }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+                <%= link_to 'お気に入り', favorite_products_path, data: { turbo_method: :get }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
               </li>
               <li>
-                <%= link_to 'チャット', chat_path, data: { turbo: :false }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white'  %>
+                <%= link_to 'チャット', chat_path, data: { turbo: :false }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false }  %>
               </li>
               <li>
-                <%= link_to '購入履歴', orders_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+                <%= link_to '購入履歴', orders_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
               </li>
               <li>
-              <%= link_to 'ダウンロードリスト', download_products_path, data: { turbo_method: :get }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+              <%= link_to 'ダウンロードリスト', download_products_path, data: { turbo_method: :get }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
               </li>
               <li>
-                <%= link_to 'アカウント情報', account_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+                <%= link_to 'アカウント情報', account_path, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
               </li>
               <li>
-                <%= link_to 'ログアウト', destroy_customer_account_session_path, data: { turbo_method: :delete }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+                <%= link_to 'ログアウト', destroy_customer_account_session_path, data: { turbo_method: :delete }, class: 'block px-4 py-2 font-bold hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
               </li>
             <% else %>
               <li>
@@ -151,10 +151,10 @@
                 </div>
               </li>
               <li>
-                <%= link_to 'アカウント作成', new_customer_account_registration_path, data: { turbo_method: :get }, class: 'block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+                <%= link_to 'アカウント作成', new_customer_account_registration_path, data: { turbo_method: :get }, class: 'block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
               </li>
               <li>
-                <%= link_to 'ログイン', new_customer_account_session_path, data: { turbo_method: :get }, class: 'block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+                <%= link_to 'ログイン', new_customer_account_session_path, data: { turbo_method: :get }, class: 'block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
               </li>
             <% end %>
           </ul>
@@ -166,16 +166,16 @@
                 </p>
               </li>
               <li>
-                <%= link_to '絵画', search_products_path(q: { product_category_name_eq: '絵画' }), data: { turbo_method: :get }, class: 'block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+                <%= link_to '絵画', search_products_path(q: { product_category_name_eq: '絵画' }), data: { turbo_method: :get }, class: 'block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
               </li>
               <li>
-                <%= link_to '彫刻', search_products_path(q: { product_category_name_eq: '彫刻' }), data: { turbo_method: :get }, class: 'block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+                <%= link_to '彫刻', search_products_path(q: { product_category_name_eq: '彫刻' }), data: { turbo_method: :get }, class: 'block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
               </li>
               <li>
-                <%= link_to '写真', search_products_path(q: { product_category_name_eq: '写真' }), data: { turbo_method: :get }, class: 'block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+                <%= link_to '写真', search_products_path(q: { product_category_name_eq: '写真' }), data: { turbo_method: :get }, class: 'block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
               </li>
               <li>
-                <%= link_to 'イラスト', search_products_path(q: { product_category_name_eq: 'イラスト' }), data: { turbo_method: :get }, class: 'block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white' %>
+                <%= link_to 'イラスト', search_products_path(q: { product_category_name_eq: 'イラスト' }), data: { turbo_method: :get }, class: 'block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white', data: { turbo: false } %>
               </li>
             </ul>
           </div>

--- a/src/compose.prod.yml
+++ b/src/compose.prod.yml
@@ -29,6 +29,7 @@ services:
       DOMAINS: "art-sa2.com -> http://web:80"
       STAGE: "production"
       CLIENT_MAX_BODY_SIZE: 100M
+      WEBSOCKET: "true"
     volumes:
       - https-portal-data:/var/lib/https-portal
 

--- a/src/compose.stg.yml
+++ b/src/compose.stg.yml
@@ -29,6 +29,7 @@ services:
       DOMAINS: "art-sa2-stg.com -> http://web:80"
       STAGE: "production"
       CLIENT_MAX_BODY_SIZE: 100M
+      WEBSOCKET: "true"
     volumes:
       - https-portal-data:/var/lib/https-portal
 

--- a/src/config/cable.yml
+++ b/src/config/cable.yml
@@ -5,9 +5,8 @@ test:
   adapter: test
 
 production:
-  adapter: async
+  adapter: 
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  channel_prefix: art_sa2
   # 管理者側のチャットリストだけのためasyncに設定してます。
   # 大量のアクセスが来る場合はredisに変更します
-  # adapter: redis
-  # url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  # channel_prefix: docker_rails_test_production

--- a/src/config/cable.yml
+++ b/src/config/cable.yml
@@ -5,6 +5,9 @@ test:
   adapter: test
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: docker_rails_test_production
+  adapter: async
+  # 管理者側のチャットリストだけのためasyncに設定してます。
+  # 大量のアクセスが来る場合はredisに変更します
+  # adapter: redis
+  # url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  # channel_prefix: docker_rails_test_production

--- a/src/config/cable.yml
+++ b/src/config/cable.yml
@@ -5,7 +5,7 @@ test:
   adapter: test
 
 production:
-  adapter: 
+  adapter: async
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: art_sa2
   # 管理者側のチャットリストだけのためasyncに設定してます。

--- a/src/config/environments/production.rb
+++ b/src/config/environments/production.rb
@@ -47,8 +47,8 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
-  # config.action_cable.url = "wss://#{ENV['HOST']}/cable"
-  # config.action_cable.allowed_request_origins = [ "https://#{ENV['HOST']}", /https:\/\/#{Regexp.escape(ENV['HOST'])}.*/ ]
+  config.action_cable.url = "wss://#{ENV['MAIL_HOST']}/cable"
+  config.action_cable.allowed_request_origins = [ "https://#{ENV['MAIL_HOST']}", /https:\/\/#{Regexp.escape(ENV['MAIL_HOST'])}.*/ ]
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.

--- a/src/config/environments/production.rb
+++ b/src/config/environments/production.rb
@@ -47,8 +47,8 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
-  # config.action_cable.url = "wss://example.com/cable"
-  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
+  config.action_cable.url = "wss://#{ENV['HOST']}/cable"
+  config.action_cable.allowed_request_origins = [ "https://#{ENV['HOST']}", /https:\/\/#{Regexp.escape(ENV['HOST'])}.*/ ]
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.

--- a/src/config/environments/production.rb
+++ b/src/config/environments/production.rb
@@ -47,8 +47,8 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
-  config.action_cable.url = "wss://#{ENV['HOST']}/cable"
-  config.action_cable.allowed_request_origins = [ "https://#{ENV['HOST']}", /https:\/\/#{Regexp.escape(ENV['HOST'])}.*/ ]
+  # config.action_cable.url = "wss://#{ENV['HOST']}/cable"
+  # config.action_cable.allowed_request_origins = [ "https://#{ENV['HOST']}", /https:\/\/#{Regexp.escape(ENV['HOST'])}.*/ ]
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.

--- a/src/config/environments/production.rb
+++ b/src/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # アプリへのアクセスをすべて強制的にSSL経由にする
-  config.force_ssl = true 
+  config.force_ssl = false
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)

--- a/src/config/importmap.rb
+++ b/src/config/importmap.rb
@@ -5,3 +5,5 @@ pin '@hotwired/turbo-rails', to: 'turbo.min.js'
 pin '@hotwired/stimulus', to: 'stimulus.min.js'
 pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js'
 pin_all_from 'app/javascript/controllers', under: 'controllers'
+pin "@rails/actioncable", to: "actioncable.esm.js"
+pin_all_from "app/javascript/channels", under: "channels"

--- a/src/config/importmap.rb
+++ b/src/config/importmap.rb
@@ -5,5 +5,5 @@ pin '@hotwired/turbo-rails', to: 'turbo.min.js'
 pin '@hotwired/stimulus', to: 'stimulus.min.js'
 pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js'
 pin_all_from 'app/javascript/controllers', under: 'controllers'
-pin "@rails/actioncable", to: "actioncable.esm.js"
-pin_all_from "app/javascript/channels", under: "channels"
+pin '@rails/actioncable', to: 'actioncable.esm.js'
+pin_all_from 'app/javascript/channels', under: 'channels'

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -33,7 +33,11 @@ Rails.application.routes.draw do
     end
     resources :products, only: %i[index edit destroy update new create]
     resources :shippings, only: %i[index edit update]
-    resources :chats, only: %i[index show]
+    resources :chats, only: %i[index show] do
+      member do
+        post :update_status
+      end
+    end
     get 'token/chats', to: 'chats#token'
   end
 

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   root 'home#index'
+  mount ActionCable.server => '/cable'
 
   # アカウント認証(カスタマー)
   devise_for :customer_accounts, controllers: {

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -22,9 +22,6 @@ Rails.application.routes.draw do
   get 'sample', to: 'samples#index'
   get 'customer-test', to: 'customer_tests#index'
 
-  # Defines the root path route ("/")
-  # root "posts#index"
-
   # 管理者のルーティング
   namespace :admin do
     namespace :products do
@@ -61,7 +58,9 @@ Rails.application.routes.draw do
     resources :orders, only: [:index]
     resource :account, only: %i[show edit update]
     resources :contacts, only: %i[new create]
-    resource :chat, only: [:show]
+    resource :chat, only: [:show] do
+      post :update_status, on: :member # 修正点
+    end
     get '/chat/token', to: 'chats#token'
   end
 

--- a/src/spec/channels/chat_channel_spec.rb
+++ b/src/spec/channels/chat_channel_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ChatChannel, type: :channel do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
チャットリストのステータス変更

以下のPRと連動してます。
ソースコードを反映してから確認お願いします。

https://github.com/recursion-backend-projects/E-Commerce-Chat-Microservice/pull/14

## 目的

複数オペレーターがチャットの状態をリアルタイムで確認しながらチャット対応できるようにする

## やったこと

- action cableの導入
- 管理者がチャットリストに参加すると「対応中」に変更
- 接続が切れた際に相手の接続も解除してチャットリストに反映
- 画面遷移すると接続が解除させる(相手のwebsocketも解除)
- STG環境でもチャット機能を動作させる

## やってないこと
- 特になし

## 確認方法
### チャットへの参加確認
1. 顧客アカウントでチャットにアクセス
2. 管理者アカウントで複数タブを開き(リストの変更を確認するため)チャットリストにアクセス
3. チャットに接続したらチャットリストのステータスが非同期で「対応中」に変更されればOK

### 接続解除の確認方法
1. チャットへの参加は上記と同様
2. 管理者もしくは顧客側で「接続解除」ボタンを押したら非同期でチャットリストから削除される
3. 解除された側にもアラートが表示されてればOK
4. チャットリストなど他のページに画面遷移した時も同様の挙動が確認できればOK

STGでも動作確認済みです。
他の方のPRと競合した時は[こちら](https://github.com/recursion-backend-projects/E-Commerce-Webapp-with-Stripe-Sync/actions/runs/9865961247)を実行してください。

## レビューで見てほしいこと、不安に思っていること

- ステータス変更時にリアルタイムで反映されるか
- 管理者参加時に対応中ステータスに問題なく切り替わるか
- 接続解除ボタンは問題なく動作するか
- 画面遷移をすると接続は解除されるか
- 片方の通信が解除されたらもう片方も通信が解除されるか

## その他
何かあればどうぞ